### PR TITLE
fix the unterminated string literal error when server startup

### DIFF
--- a/modules/es-extensions/publisher/configs/publisher-tenant.json
+++ b/modules/es-extensions/publisher/configs/publisher-tenant.json
@@ -14,7 +14,7 @@
     "application": {
         "landingPage": "/asts/gadget/list"
     },
-    "assets":["gadget","site","service","wsdl],
+    "assets":["gadget","site","service","wsdl"],
     "authentication": {
         "activeMethod": "sso",
         "methods": {


### PR DESCRIPTION
Fix the G-reg 5.0.0 SNAPSHOT server start up issue related to an unterminated string literal.