### PR TITLE
Correct the hardcoded kernel version

### DIFF
--- a/modules/distribution/src/main/assembly/bin.xml
+++ b/modules/distribution/src/main/assembly/bin.xml
@@ -444,7 +444,7 @@
 
         <!--application-authentication framework related config-->
         <fileSet>
-            <directory>../p2-profile-gen/target/wso2carbon-core-4.3.0-SNAPSHOT/repository/conf/identity</directory>
+            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/identity</directory>
             <outputDirectory>${pom.artifactId}-${build.version}/repository/conf/identity</outputDirectory>
             <includes>
                 <include>*/**</include>


### PR DESCRIPTION
In bin.xml, application-authentication framework related config had hard coded kernel snapshot version.
Replaced it with version property.