### PR TITLE
fix ResourceNotFoundException when updating a service

### DIFF
--- a/modules/es-extensions/publisher/asset/service/asset.js
+++ b/modules/es-extensions/publisher/asset/service/asset.js
@@ -230,10 +230,6 @@ asset.manager=function(ctx){
 
             log.info('Service successfully updated');
             options.id = artifact.getId();
-
-            wsdlUUID = getRegistry(ctx.session).registry.get(options.attributes.interface_wsdlURL).getUUID();
-
-            log.info(wsdlUUID);
         }
 	}
 };


### PR DESCRIPTION
When updating a service created without a wsdl url, a 'ResourceNotFoundExceptionResourceNotFoundException' was thrown in BE.
This was due to , trying to log wsdluuid in the update method. When there is no wsdl, it gives that exception.
Thus, removed the line.