### PR TITLE
add new app extension to enable service & wsdl estensions

### DIFF
--- a/modules/distribution/src/main/assembly/bin.xml
+++ b/modules/distribution/src/main/assembly/bin.xml
@@ -1,5 +1,5 @@
 <!--
- ~ Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~ Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  ~
  ~ WSO2 Inc. licenses this file to you under the Apache License,
  ~ Version 2.0 (the "License"); you may not use this file except
@@ -378,7 +378,13 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/jaggeryapps/store/extensions/assets/service</outputDirectory>
         </fileSet>
 
-	<!-- ES Extensions for G-Reg impact analysis UI-->
+        <!-- ES App Extension for G-Reg Publisher-->
+        <fileSet>
+            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/publisher/extensions/app/greg_publisher</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/jaggeryapps/publisher/extensions/app/greg_publisher</outputDirectory>
+        </fileSet>
+
+        <!-- ES Extensions for G-Reg impact analysis UI-->
         <fileSet>
             <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/publisher/extensions/app/greg_impact</directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/jaggeryapps/publisher/extensions/app/greg_impact</outputDirectory>

--- a/modules/es-extensions/publisher/extensions/app/greg_publisher/app.js
+++ b/modules/es-extensions/publisher/extensions/app/greg_publisher/app.js
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+app.dependencies=['publisher_common'];
+//override publisher-common and enable 'service' & 'wsdl'.
+//change the landing page to 'service'.
+app.server = function(ctx) {
+    return {
+        configs: {
+            landingPage: '/asts/service/list',
+            disabledAssets: ['ebook', 'api','policy','proxy','schema','sequence','servicex','uri','wadl','endpoint',
+                             'site','provider','gadget','document']
+        }
+    }
+};


### PR DESCRIPTION
with the fix[1], created our own app extension to enabel showing 'service' & 'wsdl' extansions in the publisher & disabled default assets coming from ES (document,provider,site,gadget).
Updated the bin.xml to copy it to necessary location.





[1]https://github.com/wso2/product-es/pull/144 