### PR TITLE
update bin.xml to copy security related files

### DIFF
--- a/modules/distribution/src/main/assembly/bin.xml
+++ b/modules/distribution/src/main/assembly/bin.xml
@@ -47,6 +47,8 @@
                 <exclude>**/log4j.properties</exclude>
                 <exclude>**/master-datasources.xml</exclude>
                 <exclude>**/identity.xml</exclude>
+                <exclude>**/claim-config.xml</exclude>
+                <exclude>**/email/email-admin-config.xml</exclude>
                 <!--<exclude>**/lib/org.wso2.carbon.server-${carbon.kernel.version}.jar</exclude>-->
 
             </excludes>
@@ -684,6 +686,33 @@
             <fileMode>644</fileMode>
         </file>
 
+        <!-- copy claim-config.xml -->
+        <file>
+            <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/claim-config.xml
+            </source>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
+        <!-- copy email-admin-config.xml-->
+        <file>
+            <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/email/email-admin-config.xml
+            </source>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/email</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
+        <!-- copy identity-mgt.properties-->
+        <file>
+            <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/security/identity-mgt.properties
+            </source>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/security</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
         <!--file>
             <source>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/security/idp-config.xml


### PR DESCRIPTION
G-Reg pack didnt have 'claim-config.xml' file in repository/conf .  It resulted giving an exception
ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultStepBasedSequenceHandler} -  Claim handling failed!
org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException(Intermittent)

Thus, copied it in bin.xml.
Likewise copied email-admin-config.xml & identity-mgt.properties file to our pack.