### PR TITLE
Changing the way nodes are tracked in dependency graph

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg_impact/modules/dataPopulator.js
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/modules/dataPopulator.js
@@ -32,8 +32,8 @@ function getNodesAndEdges(registry,resourcePath, graph){
     if (artifact){
         var graphDataObject = new Object();
 
-        if (graph.nodes[artifact.path]){
-            graphDataObject = graph.nodes[artifact.path]
+        if (graph.nodes[resourcePath]){
+            graphDataObject = graph.nodes[resourcePath]
         }
         else{
 
@@ -41,7 +41,7 @@ function getNodesAndEdges(registry,resourcePath, graph){
 
             graph.index++;
 
-            graph.nodes[artifact.path] = graphDataObject;
+            graph.nodes[resourcePath] = graphDataObject;
             graph.nodes.push(graphDataObject);
 
 
@@ -169,7 +169,7 @@ function createNode(resourcePath, artifact, nodeID){
 
     graphDataObject.nodeType = (graph.index == 0) ? 'parent' : 'child';
     graphDataObject.mediaType = mediaType;
-    graphDataObject.path = artifact.path;
+    graphDataObject.path = resourcePath;
     graphDataObject.relations = [];
     graphDataObject.id = nodeID;
 

--- a/modules/es-extensions/publisher/extensions/app/greg_impact/modules/dataPopulator.js
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/modules/dataPopulator.js
@@ -24,11 +24,17 @@ param registry : user-registry instance create on the logged in user's session
 param resourcePath : Source path to start data structure
 param graph : is an json object having to attributes nodes and edges
  */
-function getNodesAndEdges(registry,resourcePath, graph){
+function getNodesAndEdges(registry, userName, resourcePath, graph){
     var util = require('/extensions/app/greg_impact/modules/utility.js');
     var governanceUtils = Packages.org.wso2.carbon.governance.api.util.GovernanceUtils;
+
+    var govRegistry = governanceUtils.getGovernanceUserRegistry(registry.registry, userName);
+
+    var artifactPath = resourcePath.replace("/_system/governance", "");
+
     var artifact = governanceUtils.retrieveGovernanceArtifactByPath(
-        registry.registry,resourcePath);
+        govRegistry, artifactPath);
+
     if (artifact){
         var graphDataObject = new Object();
 
@@ -51,7 +57,7 @@ function getNodesAndEdges(registry,resourcePath, graph){
                     if (associations[i].src == resourcePath){
                         var resourceDest = associations[i].dest;
 
-                        if(getNodesAndEdges(registry, resourceDest, graph)){
+                        if(getNodesAndEdges(registry, userName, resourceDest, graph)){
                             
                             var relation = createRelation(graphDataObject.id, graph.nodes[resourceDest].id, associations[i].type, graph.relationIndex);
 

--- a/modules/es-extensions/publisher/extensions/app/greg_impact/pages/index.jag
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/pages/index.jag
@@ -92,7 +92,7 @@ else {
                 graph.index = 0;
                 graph.relationIndex = 0;
 
-                dataPopulator.getNodesAndEdges(registry, inputParameters.path, graph);
+                dataPopulator.getNodesAndEdges(registry, user.username, inputParameters.path, graph);
                 //log.info(graph);
                 obj = graph;
             }


### PR DESCRIPTION
changing impact analysis, dependency graph to use resource paths instead of artifact.path