### PR TITLE
update publisher/store

### DIFF
--- a/modules/es-extensions/publisher/asset/service/asset.js
+++ b/modules/es-extensions/publisher/asset/service/asset.js
@@ -1,25 +1,23 @@
 /*
-* Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
-asset.manager=function(ctx){
-    var getRegistry = function(cSession){
-            var userMod = require('store').user;
-            var userRegistry = userMod.userRegistry(cSession);
-
-            return userRegistry;
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+asset.manager = function(ctx) {
+    var getRegistry = function(cSession) {
+        var userMod = require('store').user;
+        var userRegistry = userMod.userRegistry(cSession);
+        return userRegistry;
     };
     var setAttributes = function(artifact, attributes) {
         for (name in attributes) {
@@ -33,13 +31,11 @@ asset.manager=function(ctx){
             }
         }
     }
-
     var setId = function(artifact, id) {
         if (id) {
             artifact.id = id;
-        }    
+        }
     }
-
     var setContent = function(artifact, content) {
         if (content) {
             if (content instanceof Stream) {
@@ -47,233 +43,190 @@ asset.manager=function(ctx){
             } else {
                 artifact.setContent(new java.lang.String(content).getBytes());
             }
-        }  
+        }
     }
-
     var createOMContent = function(attributes) {
         var omContent = "<metadata xmlns=\"http://www.wso2.org/governance/metadata\"><overview><name>";
         omContent += attributes.overview_name;
         omContent += "</name><namespace>";
-
         omContent += attributes.overview_namespace;
-
         omContent += "</namespace><version>";
         omContent += attributes.overview_version;
-        omContent += "</version></overview><interface>";
-
-        if(attributes.interface_wsdlURL || attributes.interface_wsdlUrl) {
+        omContent += "</version>";
+        if (attributes.overview_description) {
+            omContent += "<description>";
+            omContent += attributes.overview_description;
+            omContent += "</description>";
+        }
+        omContent += "</overview>";
+        //TODO:Need to add OMElement for 'contacts' & 'endpoints'.
+        //It is delayed due to ES not retreiving values given to 'options-text'
+        //But, values get added to 'attributes' if created from mgt console.
+        omContent += "<interface>";
+        if (attributes.interface_wsdlURL || attributes.interface_wsdlUrl) {
             omContent += "<wsdlURL>";
-            if(attributes.interface_wsdlUrl) {
+            if (attributes.interface_wsdlUrl) {
                 omContent += attributes.interface_wsdlUrl;
             } else {
-                omContent += attributes.interface_wsdlURL;   
+                omContent += attributes.interface_wsdlURL;
             }
             omContent += "</wsdlURL>";
         }
-
-        if(attributes.interface_transportProtocols) {
+        if (attributes.interface_transportProtocols) {
             omContent += "<transportProtocols>";
             omContent += attributes.interface_transportProtocols;
             omContent += "</transportProtocols>";
         }
-
-        if(attributes.interface_messageFormats) {
+        if (attributes.interface_messageFormats) {
             omContent += "<messageFormats>";
             omContent += attributes.interface_messageFormats;
             omContent += "</messageFormats>";
         }
-
-        if(attributes.interface_messageExchangePatterns) {
+        if (attributes.interface_messageExchangePatterns) {
             omContent += "<messageExchangePatterns>";
             omContent += attributes.interface_messageExchangePatterns;
             omContent += "</messageExchangePatterns>";
         }
-
         omContent += "</interface>";
-
-        if(attributes.docLinks_documentType) {
+        if (attributes.docLinks_documentType) {
             omContent += "<docLinks>";
-
             omContent += "<documentType>";
             omContent += attributes.docLinks_documentType;
             omContent += "</documentType>";
-
-            if(attributes.docLinks_url) {
+            if (attributes.docLinks_url) {
                 omContent += "<url>";
                 omContent += attributes.docLinks_url;
                 omContent += "</url>";
             }
-
-            if(attributes.docLinks_documentComment) {
+            if (attributes.docLinks_documentComment) {
                 omContent += "<documentComment>";
                 omContent += attributes.docLinks_documentComment;
                 omContent += "</documentComment>";
             }
-
-            if(attributes.docLinks_documentType1) {
+            if (attributes.docLinks_documentType1) {
                 omContent += "<documentType1>";
                 omContent += attributes.docLinks_documentType1;
                 omContent += "</documentType1>";
-
-                if(attributes.docLinks_url1) {
+                if (attributes.docLinks_url1) {
                     omContent += "<url1>";
                     omContent += attributes.docLinks_url1;
                     omContent += "</url1>";
                 }
-
-                if(attributes.docLinks_documentComment1) {
+                if (attributes.docLinks_documentComment1) {
                     omContent += "<documentComment1>";
                     omContent += attributes.docLinks_documentComment1;
                     omContent += "</documentComment1>";
                 }
             }
-
-            if(attributes.docLinks_documentType2) {
+            if (attributes.docLinks_documentType2) {
                 omContent += "<documentType2>";
                 omContent += attributes.docLinks_documentType2;
                 omContent += "</documentType2>";
-
-                if(attributes.docLinks_url2) {
+                if (attributes.docLinks_url2) {
                     omContent += "<url2>";
                     omContent += attributes.docLinks_url2;
                     omContent += "</url2>";
                 }
-
-                if(attributes.docLinks_documentComment2) {
+                if (attributes.docLinks_documentComment2) {
                     omContent += "<documentComment2>";
                     omContent += attributes.docLinks_documentComment2;
                     omContent += "</documentComment2>";
                 }
             }
-
             omContent += "</docLinks>";
         }
-
         omContent += "</metadata>";
-
         return omContent;
     }
-
-    var createArtifact = function (manager, options) {
+    var createArtifact = function(manager, options) {
         var attributes = options.attributes;
         var omContent = createOMContent(attributes);
-
         var artifact = manager.newGovernanceArtifact(omContent);
-
         log.info('Finished creating Governance Artifact');
-        
         setAttributes(artifact, attributes);
         setId(artifact, options.id);
         setContent(artifact, options.content);
-
         var lc = options.lifecycles;
-
         if (lc) {
             length = lc.length;
             for (var i = 0; i < length; i++) {
                 artifact.attachLifeCycle(lc[i]);
             }
         }
-
         log.info('lifecycle is attached');
-
         return artifact;
     };
-
-
-	return{
-        get:function(id){
-            var asset = this._super.get.call(this,id);
-            if(asset.attributes.interface_wsdlURL) {
+    return {
+        get: function(id) {
+            var asset = this._super.get.call(this, id);
+            if (asset.attributes.interface_wsdlURL) {
                 var wsdlUUID = getRegistry(ctx.session).registry.get(asset.attributes.interface_wsdlURL).getUUID();
                 asset.wsdl_uuid = wsdlUUID;
                 asset.wsdl_url = asset.attributes.interface_wsdlURL;
             }
-
             return asset;
         },
-        combineWithRxt:function(asset) {
-            var modAsset = this._super.combineWithRxt.call(this,asset);
-
-            if(asset.wsdl_uuid) {
+        combineWithRxt: function(asset) {
+            var modAsset = this._super.combineWithRxt.call(this, asset);
+            if (asset.wsdl_uuid) {
                 var wsdlUUID = asset.wsdl_uuid;
                 modAsset.wsdl_uuid = wsdlUUID;
             }
-
-            if(asset.wsdl_url) {
+            if (asset.wsdl_url) {
                 var wsdlURL = asset.wsdl_url;
                 modAsset.wsdl_url = wsdlURL;
-
-                modAsset.tables[2].fields.wsdlUrl.value = modAsset.wsdl_url ;
+                modAsset.tables[2].fields.wsdlUrl.value = modAsset.wsdl_url;
             }
-
             return modAsset;
         },
-		create:function(options){
-			var log = new Log();
-			var manager = this.am.manager;
-
-            var artifact = createArtifact(manager, options);
-			manager.addGenericArtifact(artifact);
-
-			log.info('Service successfully created');
-            options.id = artifact.getId();
-		},
-        update:function(options){
+        create: function(options) {
             var log = new Log();
             var manager = this.am.manager;
-
-            var asset = this.get(options.id);
-
             var artifact = createArtifact(manager, options);
-            manager.updateGenericArtifact(artifact);    
-
+            manager.addGenericArtifact(artifact);
+            log.info('Service successfully created');
+            options.id = artifact.getId();
+        },
+        update: function(options) {
+            var log = new Log();
+            var manager = this.am.manager;
+            var asset = this.get(options.id);
+            var artifact = createArtifact(manager, options);
+            manager.updateGenericArtifact(artifact);
             log.info('Service successfully updated');
             options.id = artifact.getId();
         }
-	}
+    }
 };
-
 asset.renderer = function(ctx) {
-
-    var hideTables = function(page){
+    var hideTables = function(page) {
         var tables = [];
-
-        for(var index in page.assets.tables){
-            if(page.assets.tables[index].name == 'overview'){
+        for (var index in page.assets.tables) {
+            if (page.assets.tables[index].name == 'overview') {
                 delete page.assets.tables[index].fields.scopes;
                 delete page.assets.tables[index].fields.types;
                 tables.push(page.assets.tables[index]);
-            }
-            else if(page.assets.tables[index].name == 'contacts'){
+            } else if (page.assets.tables[index].name == 'contacts') {
                 tables.push(page.assets.tables[index]);
-            }
-            else if(page.assets.tables[index].name == 'interface'){
+            } else if (page.assets.tables[index].name == 'interface') {
                 tables.push(page.assets.tables[index]);
-            }
-            else if(page.assets.tables[index].name == 'docLinks'){
+            } else if (page.assets.tables[index].name == 'docLinks') {
                 tables.push(page.assets.tables[index]);
             }
         }
-
         page.assets.tables = tables;
-
         return page;
     };
-
     return {
         create: function(page) {
             return hideTables(page);
         },
-
         update: function(page) {
             return hideTables(page);
         },
-
         list: function(page) {
             return hideTables(page);
         },
-
         details: function(page) {
             return hideTables(page);
         }

--- a/modules/es-extensions/publisher/asset/service/themes/default/partials/view-asset.hbs
+++ b/modules/es-extensions/publisher/asset/service/themes/default/partials/view-asset.hbs
@@ -12,63 +12,80 @@
 * See the License for the specific language governing permissions and
 * limitations under the License. 
 -->
-
-<!-- {{ dump .}} -->
-<!-- {{ dump assets}} -->
-<!-- {{#with assets}} -->
+        <!-- {{#with assets}} -->
 <div class='content-div'>
-	<div class="tab-content asset-tab-content">
-		<div id="view" class="asset-view-container">
+    <div class="tab-content asset-tab-content">
+        <div id="view" class="asset-view-container">
             <div class="row-fluid asset-detail-top-row">
                 <div class="span2">
-                            <div class="thumbnail-div">
-                                <img src='{{url ""}}/extensions/assets/service/themes/default/imgs/thumbnail.jpg' class="" alt="Thumb"/>
-
-                            </div>
+                    <div class="thumbnail-div">
+                        <img src='{{url ""}}/extensions/assets/service/themes/default/imgs/thumbnail.jpg' class="" alt="Thumb"/>
+                    </div>
                 </div>
                 <div class="span10 asset-details-box">
-                        <h4>{{name}}</h4>
+                    <h4>{{name}}</h4>
                 </div>
             </div>
-		    <div class="row-fluid asset-details-row">
-		                <div class="span12 asset-content-box">
-		                    <div class="widget wlightblue">
-		                        <div class="widget-head">
-                                    <div class="pull-left">Asset Overview</div>
-                                    <div class="clearfix"></div>
-                                </div>
+            <div class="row-fluid asset-details-row">
+                <div class="span12 asset-content-box">
+                    <div class="widget wlightblue">
+                        <div class="widget-head">
+                            <div class="pull-left">Asset Overview</div>
+                            <div class="clearfix"></div>
+                        </div>
 
-                                <div class="widget-content">
-                                        <table class="table table-bordered asset-view-table widget-table">
-                                            <tbody>
-                                            {{#each tables}}
-                                                
-                                                <tr>
-                                                   {{renderTablePreview .}}
-                                                </tr>
-
-                                        
+                        <div class="widget-content">
+                            <table class="table table-bordered asset-view-table widget-table">
+                                <tbody>
+                                <tr>
+                                    {{renderTablePreview tables.[0]}}
+                                </tr>
+                                <tr class="table table-striped table-hover">
+                                    {{renderTablePreview tables.[1]}}
+                                </tr>
+                                <!-- Customize the 'interface' table to provide a link for wsdl url. -->
+                                <tr>
+                                    <h4 class='rxt-table-heading'>{{t "Interface"}}</h4>
+                                    <table class='table'>
+                                        <tr>
+                                            <td>{{t "WSDL/WADL URL"}}</td>
+                                            <td><a href="../../../asts/wsdl/details/{{wsdl_uuid}}">{{wsdl_url}}</a></td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{t "Transport Protocols"}}</td>
+                                            <td>{{tables.[2].fields.transportProtocols.value}}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{t "Message Formats"}}</td>
+                                            <td>{{tables.[2].fields.messageFormats.value}}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{t "Message Exchange Patterns"}}</td>
+                                            <td>{{tables.[2].fields.messageExchangePatterns.value}}</td>
+                                        </tr>
+                                    </table>
+                                </tr>
+                                <tr class="table table-striped table-hover">
+                                    {{renderTablePreview tables.[3]}}
+                                </tr>
+                                {{#if tags}}
+                                    <tr>
+                                        <td class="span3">Tags</td>
+                                        <td>
+                                            {{#each tags}}
+                                                <span class="view-tag">{{this}}</span>
                                             {{/each}}
-                                        
-                                            {{#if tags}}
-                                            
-                                                <tr>
-                                                    <td class="span3">Tags</td>
-                                                    <td>
-                                                    	{{#each tags}}
-                                                        <span class="view-tag">{{this}}</span>
-                                                        {{/each}}
-                                                    </td>
-                                                </tr>
-                                            {{/if}}
-                                            </tbody>
-                                        </table>
-                                </div>
-                            </div>
-		                </div>
-		    </div>
+                                        </td>
+                                    </tr>
+                                {{/if}}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-	</div>
+    </div>
 </div>
 {{/with}}
 

--- a/modules/es-extensions/publisher/asset/wsdl/apis/wsdls.jag
+++ b/modules/es-extensions/publisher/asset/wsdl/apis/wsdls.jag
@@ -1,0 +1,81 @@
+<%
+/*
+ * Copyright (c) 2014, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ Description: Invoke custom wsdl api endpoint to handle file upload.
+ Filename : wsdls.jag
+ */
+require('/modules/publisher.js').exec(function (ctx) {
+    var utils = require('utils');
+    var req = ctx.request;
+    var ref = utils.file;
+    var inputStream = Packages.java.io.InputStream;
+    var ByteArrayDataSource = Packages.org.apache.axiom.attachments.ByteArrayDataSource;
+    var IOUtils = Packages.org.apache.commons.io.IOUtils;
+    var DataHandler = Packages.javax.activation.DataHandler;
+    var Array = Packages.java.lang.reflect.Array;
+    var addResourceUtils=Packages.org.wso2.carbon.registry.resource.services.utils.AddResourceUtil;
+    //request contains the version & name of the zip file
+    var version=req.getParameter('file_version');
+    var wsdlFileName=req.getParameter('wsdl_file_name');
+    var path="/_system/governance/trunk/wsdls/".concat(version).concat('/').concat(wsdlFileName);
+
+    //get the uploaded zip file.
+    var files=req.getAllFiles();
+    //get the file with entry 'wsdl_zip'
+    var file=files["wsdl_file"];
+    var extension = ref.getExtension(file);
+    var mediaType;
+    var content;
+    var properties;
+    //open the file for 'read' operation.
+    file.open("r");
+    //get the fileinput stream
+    inputStream = file.getStream().getStream();
+    var bytes = IOUtils.toByteArray(inputStream);
+    //use ByteArrayDataSource to pass to datahandler.
+    //It requires constructor parameters byte[].
+    var byteDataSource;
+    if(extension == 'zip'){
+        //mediatype for wsdl zip file.
+        mediaType="application/vnd.wso2.governance-archive";
+        byteDataSource = new ByteArrayDataSource(bytes,"application/zip");
+        content = new DataHandler(byteDataSource);
+        properties = Array.newInstance(java.lang.String, 2, 2);
+        //use JS array
+        properties[0][0] = 'registry.mediaType';
+        properties[0][1] = 'application/wsdl+xml';
+        properties[1][0] = 'version';
+        properties[1][1] = version;
+    }else if(extension == 'wsdl'){
+        mediaType = "application/wsdl+xml";
+        byteDataSource = new ByteArrayDataSource(bytes,"text/xml");
+        content = new DataHandler(byteDataSource);
+        properties = Array.newInstance(java.lang.String, 1, 2);
+        properties[0][0] = 'version';
+        properties[0][1] = version;
+    }
+    //close the file.
+    file.close();
+    var description="";
+    var symlinkLocation = '';
+    var userMod = require('store').user;
+    var userRegistry = userMod.userRegistry(ctx.session);
+    var registry = userRegistry.registry;
+    //use AddResourceUtil in carbon-registry to add the zip file.
+    addResourceUtils.addResource(path,mediaType,description,content,symlinkLocation,registry,properties);
+}, request, response, session);
+%>

--- a/modules/es-extensions/publisher/asset/wsdl/asset.js
+++ b/modules/es-extensions/publisher/asset/wsdl/asset.js
@@ -1,105 +1,96 @@
-
 /*
-* Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
-asset.manager = function(ctx){
-	var getRegistry = function(cSession){
-			var userMod = require('store').user;
-			var userRegistry = userMod.userRegistry(cSession);
-
-			return userRegistry;
-	};
-	return {
-		importAssetFromHttpRequest: function(options){
-			log.info('Importing asset from request');
-			return options;
-		},
-		combineWithRxt:function(asset){
-			return asset;
-		},
-		create:function(options){
-			var url = options.overview_url;
-			var name = options.overview_name;
-			var version = options.overview_version;
-
-			var userRegistry = getRegistry(ctx.session);
-
-			var utils = Packages.org.wso2.carbon.registry.resource.services.utils.ImportResourceUtil;
-
-			var parentPath = "/_system/governance/trunk/wsdls/".concat(version);
-			var mediaType = "application/wsdl+xml";
-
-			var javaArray = Packages.java.lang.reflect.Array;
-			var properties = javaArray.newInstance(java.lang.String, 1, 2);
-
-			properties[0][0] = 'version';
-			properties[0][1] = version;
-
-			utils.importResource(parentPath, name, mediaType, '', url, '', userRegistry.registry, properties);
-		},
-		get:function(id){
-			var item = this._super.get.call(this,id);
-			var subPaths = item.path.split('/');	
-
-			item.name = subPaths[subPaths.length - 1];
-			item.version = subPaths[subPaths.length - 2];
-
-			var userRegistry = getRegistry(ctx.session);
-
-			var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;
-			var resource = userRegistry.registry.get(item.path);
-
-			item.authorUserName = resource.getAuthorUserName();
-
-			var content = resource.getContent();
-
-		    var value = '' + new Stream(new ByteArrayInputStream(content));
-			item.content = value;
-
-			return item;
-		},
-		list:function(paging){
-			var items = this._super.list.call(this,paging);
-			return items;
-		},
-		search:function(q,paging){
-			var results = this._super.search.call(this,q,paging);
-
-			for(var index = 0; index < results.length; index++){
-				var result = results[index];
-				var path = result.path;
-				var subPaths = path.split('/');
-				var name = subPaths[subPaths.length - 1];
-
-				result.name = name;
-				result.version = subPaths[subPaths.length - 2];
-			}
-
-			return results;
-		},
-		getName:function(asset){
-			return asset.name;
-		}
-	};
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+asset.manager = function(ctx) {
+    var getRegistry = function(cSession) {
+        var userMod = require('store').user;
+        var userRegistry = userMod.userRegistry(cSession);
+        return userRegistry;
+    };
+    return {
+        importAssetFromHttpRequest: function(options) {
+            log.info('Importing asset from request');
+            return options;
+        },
+        combineWithRxt: function(asset) {
+            return asset;
+        },
+        create: function(options) {
+            var url = options.overview_url;
+            var name = options.overview_name;
+            var version = options.overview_version;
+            var userRegistry = getRegistry(ctx.session);
+            var utils = Packages.org.wso2.carbon.registry.resource.services.utils.ImportResourceUtil;
+            var parentPath = "/_system/governance/trunk/wsdls/".concat(version);
+            var mediaType = "application/wsdl+xml";
+            var javaArray = Packages.java.lang.reflect.Array;
+            var properties = javaArray.newInstance(java.lang.String, 1, 2);
+            properties[0][0] = 'version';
+            properties[0][1] = version;
+            utils.importResource(parentPath, name, mediaType, '', url, '', userRegistry.registry, properties);
+        },
+        get: function(id) {
+            var item = this._super.get.call(this, id);
+            var subPaths = item.path.split('/');
+            item.name = subPaths[subPaths.length - 1];
+            item.version = subPaths[subPaths.length - 2];
+            var userRegistry = getRegistry(ctx.session);
+            var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;
+            var resource = userRegistry.registry.get(item.path);
+            item.authorUserName = resource.getAuthorUserName();
+            var content = resource.getContent();
+            var value = '' + new Stream(new ByteArrayInputStream(content));
+            item.content = value;
+            return item;
+        },
+        list: function(paging) {
+            var items = this._super.list.call(this, paging);
+            return items;
+        },
+        search: function(q, paging) {
+            var results = this._super.search.call(this, q, paging);
+            for (var index = 0; index < results.length; index++) {
+                var result = results[index];
+                var path = result.path;
+                var subPaths = path.split('/');
+                var name = subPaths[subPaths.length - 1];
+                result.name = name;
+                result.version = subPaths[subPaths.length - 2];
+            }
+            return results;
+        },
+        getName: function(asset) {
+            return asset.name;
+        }
+    };
 };
-
+asset.server = function(ctx) {
+    var type = ctx.type;
+    return {
+        endpoints: {
+            apis: [{
+                       url: 'wsdls',
+                       path: 'wsdls.jag'
+                   }]
+        }
+    };
+};
 asset.renderer =  function (ctx){
-	return {
-		details:function(page,meta){
-			return page;
-		}
-	};
+    return {
+        details:function(page,meta){
+            return page;
+        }
+    };
 };

--- a/modules/es-extensions/publisher/asset/wsdl/themes/default/helpers/create_asset.js
+++ b/modules/es-extensions/publisher/asset/wsdl/themes/default/helpers/create_asset.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2005-2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+var name;
+var hps = require('/themes/default/helpers/create_asset.js');
+var that = this;
+/*
+ In order to inherit all variables in the default helper
+ */
+for (name in hps) {
+    if (hps.hasOwnProperty(name)) {
+        that[name] = hps[name];
+    }
+}
+var fn = that.resources;
+var resources = function(page, meta) {
+
+    var o = (fn)? fn(page, meta):{css:[],js:[],code:[]};
+    if (!o.css) {
+        o.css = [];
+    }
+    o.js.push('create_form.js');
+    return o;
+};
+
+
+

--- a/modules/es-extensions/publisher/asset/wsdl/themes/default/js/create_form.js
+++ b/modules/es-extensions/publisher/asset/wsdl/themes/default/js/create_form.js
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+/**
+ * [contains actions, for creating a wsdl name when the wsdl url is selected,
+ * to show drop down menu for import & upload of wsdls,
+ * to call custom api
+ * ]
+ */
+$(function() {
+    //function to set the wsdl name from the wsdl url.
+    $('input[name="overview_url"]').change(function() {
+        var wsdlUrl = $('input[name="overview_url"]').val();
+        var wsdlFileName = "";
+        if (wsdlUrl.indexOf("\\") != -1) {
+            wsdlFileName = wsdlUrl.substring(wsdlUrl.lastIndexOf('\\') + 1, wsdlUrl.length);
+        } else {
+            wsdlFileName = wsdlUrl.substring(wsdlUrl.lastIndexOf('/') + 1, wsdlUrl.length);
+        }
+        if (wsdlFileName.search(/\.[^?]*$/i) < 0) {
+            wsdlFileName = wsdlFileName.replace("?", ".");
+            var suffix = ".wsdl";
+            if (wsdlFileName.indexOf(".") > 0) {
+                wsdlFileName = wsdlFileName.substring(0, wsdlFileName.lastIndexOf(".")) + suffix;
+            } else {
+                wsdlFileName = wsdlFileName + suffix;
+            }
+        }
+        var notAllowedChars = "!@#;%^*+={}|<>";
+        for (i = 0; i < notAllowedChars.length; i ++) {
+            var c = notAllowedChars.charAt(i);
+            wsdlFileName = wsdlFileName.replace(c, "_");
+        }
+        $('input[name="overview_name"]').val(wsdlFileName);
+    });
+    //function to display upload or import uis.
+    var uploadUI = $('#uploadUI');
+    var importUI = $('#importUI');
+    importUI.show();
+
+    $('select').on('change', function() {
+        var addSelector = $('#addMethodSelector');
+        var selectedValue = addSelector.val();
+        if (selectedValue == "upload") {
+            uploadUI.show();
+            importUI.hide();
+        } else if (selectedValue == "import") {
+            importUI.show();
+            uploadUI.hide();
+        }
+    });
+    //function to call the custom wsdl api or default api.
+    $('form[name="form-asset-create"] input[type="submit"]').click(function(event) {
+        var $form = $('form[name="form-asset-create"]');
+        if ($(this).attr("name") == 'addNewWsdlFileAssetButton') {//upload via file browser
+            //call the custom endpoint for processing wsdls upload via file browser.
+            $form.attr('action', caramel.context + '/asts/wsdl/apis/wsdls');
+            var $wsdlFileInput = $('input[name="wsdl_file"]');
+            var wsdlFileInputValue = $wsdlFileInput.val();
+            var wsdlFilePath = wsdlFileInputValue;
+            var fileName = wsdlFilePath.split('\\').reverse()[0];
+            //set the zip file name, to the hidden attribute.
+            $('input[name="wsdl_file_name"]').val(fileName);
+            $form.submit();
+        } else if ($(this).attr("name") == 'addNewAssetButton') {//upload via url.
+            //call the default endpoint.
+            $form.attr('action', caramel.context + '/apis/assets?type=wsdl');
+            $form.submit();
+        }
+    });
+});

--- a/modules/es-extensions/publisher/asset/wsdl/themes/default/partials/create_form.hbs
+++ b/modules/es-extensions/publisher/asset/wsdl/themes/default/partials/create_form.hbs
@@ -10,34 +10,61 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under the License. 
+* limitations under the License.
 -->
-
-<form  method='post' action='{{url ""}}/apis/assets?type={{rxt.shortName}}' class="form-horizontal" id="form-asset-create" data-redirect-url='{{url ""}}/asts/{{rxt.shortName}}/list' >   
+<form  method='post' class="form-horizontal" id="form-asset-create" name ="form-asset-create" data-redirect-url='{{url ""}}/asts/{{rxt.shortName}}/list' >
     <div class="control-group">
-        <label class="control-label" for="overview_url">WSDL Url</label>
-        <div class="controls">
-                <input type='text' name='overview_url' id='overview_url' /> 
+        <select id="addMethodSelector">
+            <option value="import" selected="selected">{{t "Import WSDL from a url"}}</option>
+            <option value="upload">{{t "Upload WSDL from a file"}}</option>
+        </select>
+    </div>
+    <div id="importUI" style="display: none;">
+        <div class="control-group">
+            <label class="control-label" for="overview_url">{{t "WSDL Url"}}</label>
+            <div class="controls">
+                <input type='text' name='overview_url' id='overview_url' />
+            </div>
         </div>
-    </div> 
-
-    <div class="control-group">
-        <label class="control-label" for="overview_name">Name</label>
-        <div class="controls">
-            <input type='text' name='overview_name' id='overview_name' />
+        <div class="control-group">
+            <label class="control-label" for="overview_name">{{t "Name"}}</label>
+            <div class="controls">
+                <input type='text' name='overview_name' id='overview_name' />
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label" for="overview_version">{{t "Version"}}</label>
+            <div class="controls">
+                <input type='text' name='overview_version' id='overview_version' />
+            </div>
+        </div>
+        <div id="saveButtons" class="form-actions">
+            <input type='submit' id="btn-create-asset" class="btn btn-primary" name="addNewAssetButton" value='{{t "Create"}}'>
+            <button class="btn" type="reset">{{t "Reset"}}</button>
+            <input type="hidden" value="{{rxt.shortName}}" name="{{rxt.shortName}}" id="meta-asset-type">
         </div>
     </div>
-    
-    <div class="control-group">
-        <label class="control-label" for="overview_version">Version</label>
-        <div class="controls">
-            <input type='text' name='overview_version' id='overview_version' />
+    <div id="uploadUI" style="display: none;">
+        <div class="control-group">
+            <label class="control-label" for="wsdl_zip">{{t "WSDL/Zip file"}}</label>
+            <div class="controls">
+                <input type='file' name='wsdl_file' id='wsdl_file' />
+                <!--Use a hidden field to save the zip name and pass it to request, as 'file' 
+                    attribute is not passed to the request unless it is defined in the rxt.-->
+                <input type='hidden' name='wsdl_file_name' id='wsdl_file_name' />
+            </div>
         </div>
-    </div> 
+        <div class="control-group">
+            <label class="control-label" for="file_version">{{t "Version"}}</label>
+            <div class="controls">
+                <input type='text' name='file_version' id='file_version' />
+            </div>
+        </div>
+        <div id="saveButtons" class="form-actions">
+            <input type='submit' id="btn-create-asset" class="btn btn-primary" name="addNewWsdlFileAssetButton" value='{{t "Create"}}'>
+            <button class="btn" type="reset">{{t "Reset"}}</button>
+            <input type="hidden" value="{{rxt.shortName}}" name="{{rxt.shortName}}" id="meta-asset-type">
+        </div>
+    </div>
 
-    <div id="saveButtons" class="form-actions">
-        <input type='submit' id="btn-create-asset" class="btn btn-primary" name="addNewAssetButton" value='{{t "Create"}}'>
-        <button class="btn" type="reset">{{t "Reset"}}</button>
-        <input type="hidden" value="{{rxt.shortName}}" name="{{rxt.shortName}}" id="meta-asset-type">
-    </div>   
 </form>

--- a/modules/es-extensions/publisher/asset/wsdl/themes/default/partials/view-asset.hbs
+++ b/modules/es-extensions/publisher/asset/wsdl/themes/default/partials/view-asset.hbs
@@ -15,58 +15,58 @@
 
 <!-- {{dump assets}} -->
 <!-- {{dump .}} -->
-<!-- {{#with assets}} -->
+        <!-- {{#with assets}} -->
 <div class='content-div'>
-	<div class="tab-content asset-tab-content">
-		<div id="view" class="asset-view-container">
+    <div class="tab-content asset-tab-content">
+        <div id="view" class="asset-view-container">
             <div class="row-fluid asset-detail-top-row">
                 <div class="span2">
-                            <div class="thumbnail-div">
-                                <img src='{{url ""}}/extensions/assets/service/themes/default/imgs/thumbnail.jpg' class="" alt="Thumb"/>
+                    <div class="thumbnail-div">
+                        <img src='{{url ""}}/extensions/assets/wsdl/themes/default/imgs/thumbnail.jpg' class="" alt="Thumb"/>
 
-                            </div>
+                    </div>
                 </div>
                 <div class="span10 asset-details-box">
-                        <h4>{{name}}</h4>
+                    <h4>{{name}}</h4>
                 </div>
             </div>
-		    <div class="row-fluid asset-details-row">
-		                <div class="span12 asset-content-box">
-		                    <div class="widget wlightblue">
-		                        <div class="widget-head">
-                                    <div class="pull-left">Asset Overview</div>
-                                    <div class="clearfix"></div>
-                                </div>
-                                <div class="widget-content">
-                                        <table class="table table-striped table-hover">
-                                            <tbody>
-                                                <tr>
-                                                    <td>Name</td>
-                                                    <td>{{name}}</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Version</td>
-                                                    <td>{{version}}</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Media Type</td>
-                                                    <td>{{mediaType}}</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Created by</td>
-                                                    <td>{{authorUserName}}</td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        <div id='wsdl-viewer'>
-                                            <legend><h4>Content</h4></legend>
-                                            <textarea id="wsdlcontent" name="wsdlcontent">{{content}}</textarea>
-                                        </div>
-                                </div>
+            <div class="row-fluid asset-details-row">
+                <div class="span12 asset-content-box">
+                    <div class="widget wlightblue">
+                        <div class="widget-head">
+                            <div class="pull-left">Asset Overview</div>
+                            <div class="clearfix"></div>
+                        </div>
+                        <div class="widget-content">
+                            <table class="table table-striped table-hover">
+                                <tbody>
+                                <tr>
+                                    <td>{{t "Name"}}</td>
+                                    <td>{{name}}</td>
+                                </tr>
+                                <tr>
+                                    <td>{{t "Version"}}</td>
+                                    <td>{{version}}</td>
+                                </tr>
+                                <tr>
+                                    <td>{{t "Media Type"}}</td>
+                                    <td>{{mediaType}}</td>
+                                </tr>
+                                <tr>
+                                    <td>{{t "Created by"}}</td>
+                                    <td>{{authorUserName}}</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <div id='wsdl-viewer'>
+                                <legend><h4>{{t "Content"}}</h4></legend>
+                                <textarea id="wsdlcontent" name="wsdlcontent">{{content}}</textarea>
                             </div>
-		                </div>
-		    </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-	</div>
+    </div>
 </div>
 {{/with}}

--- a/modules/features/product/org.wso2.carbon.governance.es.extensions.feature/resources/p2.inf
+++ b/modules/features/product/org.wso2.carbon.governance.es.extensions.feature/resources/p2.inf
@@ -1,0 +1,2 @@
+instructions.configure = \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.governance.es.extensions_${feature.version}/es-extensions/,target:${installFolder}/../../resources/,overwrite:true);\

--- a/modules/features/product/org.wso2.carbon.governance.jaggeryapps.feature/resources/p2.inf
+++ b/modules/features/product/org.wso2.carbon.governance.jaggeryapps.feature/resources/p2.inf
@@ -1,0 +1,2 @@
+instructions.configure = \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.governance.jaggeryapps_${feature.version}/jaggeryapps/,target:${installFolder}/../../deployment/server/jaggeryapps/,overwrite:true);\


### PR DESCRIPTION
Update publisher/store to support following functionalities:
1.Support uploading wsdl from file system:
- Support uploading wsdls as zip files.
- Support uploading wsdl as a single file. (not zip files)

2.Support getting wsdl name itself from the wsdl url, when adding a wsdl.

3.Use code-mirror library for styling wsdl/xml content.

4.When creating a Service, better to avoid displaying registry path of the wsdl, in publisher.
Suggestions to replace it: 
- Redirect to wsdl view in publisher

Further created p2.inf files for es.extensions & jaggeryapps feature.