### PR TITLE
corrects the error in viewing content type rxts, due to versioning suppo...

### DIFF
--- a/modules/es-extensions/publisher/asset/policy/asset.js
+++ b/modules/es-extensions/publisher/asset/policy/asset.js
@@ -88,6 +88,9 @@ asset.manager = function(ctx) {
          * */
         update: function(){
 
+        },
+        getAssetGroup:function(){
+            return [];
         }
     };
 };

--- a/modules/es-extensions/publisher/asset/schema/asset.js
+++ b/modules/es-extensions/publisher/asset/schema/asset.js
@@ -88,6 +88,9 @@ asset.manager = function(ctx) {
         * */
         update: function(){
 
+        },
+        getAssetGroup:function(){
+            return [];
         }
     };
 };

--- a/modules/es-extensions/publisher/asset/wadl/asset.js
+++ b/modules/es-extensions/publisher/asset/wadl/asset.js
@@ -85,6 +85,9 @@ asset.manager = function(ctx) {
         },
         update: function(){
 
+        },
+        getAssetGroup:function(){
+            return [];
         }
     };
 };

--- a/modules/es-extensions/publisher/asset/wsdl/asset.js
+++ b/modules/es-extensions/publisher/asset/wsdl/asset.js
@@ -84,6 +84,9 @@ asset.manager = function(ctx) {
         },
         update: function(){
 
+        },
+        getAssetGroup:function(){
+            return [];
         }
     };
 };


### PR DESCRIPTION
...rt

When supporting versioning support, ES checks for name attribute of each asset. COntent type RXTs like WSDL,WADL,Schemas & policies does not have name attributes.
Thus, needed to coorect it by adding amethod, in aset manager of each asset extension.