### PR TITLE
fixing stand alone building of asset modle samples - REGISTRY-2115

### DIFF
--- a/modules/samples/asset-models/ApplicationModel/pom.xml
+++ b/modules/samples/asset-models/ApplicationModel/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
             <version>${carbon.commons.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/samples/asset-models/BusinessProcessModel/pom.xml
+++ b/modules/samples/asset-models/BusinessProcessModel/pom.xml
@@ -108,6 +108,7 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
             <version>${carbon.commons.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/samples/asset-models/PeopleModel/pom.xml
+++ b/modules/samples/asset-models/PeopleModel/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
             <version>${carbon.commons.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/samples/asset-models/ProjectModel/pom.xml
+++ b/modules/samples/asset-models/ProjectModel/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
             <version>${carbon.commons.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/samples/asset-models/TestPlanModel/pom.xml
+++ b/modules/samples/asset-models/TestPlanModel/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.reporting.util</artifactId>
             <version>${carbon.commons.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -35,6 +35,11 @@
         <module>custom-ui/src/org.wso2.carbon.registry.samples.custom.topics.ui</module>
         <module>handler/src</module>
         <module>jcr-client/src</module>
+        <module>asset-models/ApplicationModel</module>
+        <module>asset-models/BusinessProcessModel</module>
+        <module>asset-models/PeopleModel</module>
+        <module>asset-models/ProjectModel</module>
+        <module>asset-models/TestPlanModel</module>
     </modules>
     <repositories>
         <repository>


### PR DESCRIPTION
Also asset model samples were added to the general product build to ensure sample are built before packing.

Reason for these sample's failure is setting of \<scope\>test\</scope\> for dependency org.wso2.carbon.reporting.util on product-greg main pom.xml.
Due to this scope set asset model samples which require \<scope\>compile\</scope\> fails when building.
According to maven documentation [2] "Furthermore, those dependencies are propagated to dependent projects". Therefore we have to restate scope if the scope is changed in a parent pom.xml file.

[1] https://wso2.org/jira/browse/REGISTRY-2115
[2] https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html