### PR TITLE
adding dependency graph depth controlling functionlity

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg_impact/pages/index.jag
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/pages/index.jag
@@ -98,6 +98,7 @@ else {
                 var dataPopulator = require("../modules/dataPopulator.js");
 
                 var graph = new Object();
+                var depth = -1;
 
                 graph.nodes = [];
                 graph.edges = [];
@@ -105,7 +106,7 @@ else {
                 graph.index = 0;
                 graph.relationIndex = 0;
 
-                dataPopulator.getNodesAndEdges(registry, user.username, inputParameters.path, graph);
+                dataPopulator.getNodesAndEdges(registry, user.username, inputParameters.path, graph, depth);
                 //log.info(graph);
                 obj = graph;
             }


### PR DESCRIPTION
With this change depth of dependency graph (longest path from dependency graph root to its farthest child) can be restricted.

By adding \<dependencyGraphMaxDepth\>{depth-value}\</dependencyGraphMaxDepth\> in to \<wso2registry\> of registry.xml  user can control the depth of the graph.

If **dependencyGraphMaxDepth element is not set** in registry.xml, dependency graph will be created **without any restriction on depth**. Also if **dependencyGraphMaxDepth is set to a negative value, dependency graph will be created without any restriction on depth**.

1. dependencyGraphMaxDepth = 0, means only source node will be displayed in dependency graph.
2. dependencyGraphMaxDepth = 1, means only source node and its immediate children will be displayed.
2. dependencyGraphMaxDepth = 2, means nodes up to grand children of source node will be displayed.