### PR TITLE
Fix for STORE-1071 and Search query persistence

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
@@ -137,6 +137,9 @@ asset.configure = function() {
             grouping: {
                 groupingEnabled: false,
                 groupingAttributes: ['overview_name']
+            },
+            notifications:{
+                enabled:false
             }
         }
     };

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -59,9 +59,9 @@
         </div>
         <div class="input-group input-wrap">
             {{#if rxt.pluralLabel}}
-                <input  id="search"  type="text" class="form-control" placeholder="Search in {{rxt.pluralLabel}}">
+                <input  id="search"  type="text" class="form-control" placeholder="Search in {{rxt.pluralLabel}}" value="{{searchQuery}}">
             {{else}}
-                <input  id="search"  type="text" class="form-control" placeholder="Search in all asset types">
+                <input  id="search"  type="text" class="form-control" placeholder="Search in all asset types" value="{{searchQuery}}">
             {{/if}}
             <div class="input-group-btn">
                 <button class="btn btn-default wrap-input-right" type="button" title="Search" id="search-button" >


### PR DESCRIPTION
This PR is related to 
- wso2/carbon-store PR:https://github.com/wso2/carbon-store/pull/286
- wso2/carbon-store PR:https://github.com/wso2/carbon-store/pull/293

**Notification Change**:
This PR disables the ES notifications in the Governance Center.

*Note*: 
This PR introduces a notifications property the asset configuration:
```javascript
 notifications :{
    enabled:true
}
```
When TRUE all users with the admin role will be subscribed to lifecycle state change and asset updates. 

**Search Textbox Change**:
The search term entered by the user is persisted
