### PR TITLE
Style changes to the download and copy link buttons

### DIFF
--- a/modules/es-extensions/store/asset/policy/asset.js
+++ b/modules/es-extensions/store/asset/policy/asset.js
@@ -180,3 +180,25 @@ asset.configure = function() {
         }
     }
 };
+
+asset.renderer = function(ctx){
+    return {
+        pageDecorators:{
+            downloadPopulator:function(page){
+                //Populate the links for downloading content RXTs
+                if(page.meta.pageName === 'details'){
+                    var isDownloadable = ctx.rxtManager.isDownloadable(page.assets.type);
+                    if(!isDownloadable){
+                        return;
+                    }
+                    var config = require('/config/store.js').config();
+                    var pluralType = 'policys';
+                    page.downloadMetaData = {}; 
+                    page.downloadMetaData.downloadFileType = page.rxt.singularLabel;
+                    page.downloadMetaData.enabled = isDownloadable;
+                    page.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenantId='+ctx.tenantId;
+                }
+            }
+        }
+    };
+};

--- a/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
@@ -11,7 +11,7 @@
 		  {{/if}}
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
 		  <a class='btn btn-default' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
-		  <a class='btn' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
+		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
 		</div>
 	</div>
 	{{/if}}

--- a/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
@@ -9,7 +9,7 @@
 		  <a class='btn btn-default' target='_blank' href='{{url ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
 		  <a class='btn btn-default' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
-		  <a class='btn' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
+		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
 		</div>
 	</div>
 	{{/if}}

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/js/copy-to-clipboard.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/js/copy-to-clipboard.js
@@ -23,8 +23,12 @@ $(function(){
 	  this.on( "aftercopy", function( event ) {
 	  	//Provide feedback to the user indicating that the 
 	  	$('#copy-button').html('<i class="fw fw-check" style="color:green"></i> Copied to clipboard');
+	  	$('#copy-button').removeClass('btn-default');
+	  	$('#copy-button').addClass('btn-warning');
 	  	setTimeout(function(){
 	  		$('#copy-button').html('<i class="fw fw-copy"></i> Copy to clipboard');
+	  		$('#copy-button').removeClass('btn-warning');
+	  		$('#copy-button').addClass('btn-default');
 	  	},2000);
 	  });
 	});


### PR DESCRIPTION
- The copy to clipboard button is highlighted in yellow for a few seconds after the user clicks on it
- The download ,copy and swagger buttons now use the default button class