### PR TITLE
Fixes REGISTRY-3232 and REGISTRY-3231

### DIFF
--- a/modules/es-extensions/store/asset/policy/asset.js
+++ b/modules/es-extensions/store/asset/policy/asset.js
@@ -193,10 +193,11 @@ asset.renderer = function(ctx){
                     }
                     var config = require('/config/store.js').config();
                     var pluralType = 'policys';
+                    var domain = require('carbon').server.tenantDomain({tenantId:ctx.tenantId});
                     page.downloadMetaData = {}; 
                     page.downloadMetaData.downloadFileType = page.rxt.singularLabel;
                     page.downloadMetaData.enabled = isDownloadable;
-                    page.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenantId='+ctx.tenantId;
+                    page.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenant='+domain;
                 }
             }
         }

--- a/modules/es-extensions/store/asset/restservice/asset.js
+++ b/modules/es-extensions/store/asset/restservice/asset.js
@@ -156,6 +156,7 @@ asset.renderer = function(ctx){
                 if(page.meta.pageName === 'details'){
                     var config = require('/config/store.js').config();
                     var pluralType = 'wadls'; //Assume it is a WADl
+                    var domain = require('carbon').server.tenantDomain({tenantId:ctx.tenantId});
                     page.assets.downloadMetaData = {}; 
                     page.assets.downloadMetaData.enabled = false;
                     var downloadFile = page.assets.dependencies.filter(function(item){
@@ -166,7 +167,7 @@ asset.renderer = function(ctx){
                       page.assets.downloadMetaData.enabled = true;  
                       page.assets.downloadMetaData.downloadFileType = typeDetails.singularLabel.toUpperCase();
                       pluralType = typeDetails.pluralLabel.toLowerCase();
-                      page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+downloadFile.associationUUID+'/content?tenantId='+ctx.tenantId;          
+                      page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+downloadFile.associationUUID+'/content?tenant='+domain;          
                       if(downloadFile.associationType == 'swagger'){
                         page.assets.downloadMetaData.swaggerUrl = '/pages/swagger?path='+downloadFile.associationPath;
                       }

--- a/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
@@ -10,7 +10,7 @@
 		  <a class='btn btn-default' target='_blank' href='{{url ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
 		  {{/if}}
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
-		  <a class='btn btn-default' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
+		  <a class='btn btn-default' target='_blank' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
 		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
 		</div>
 	</div>

--- a/modules/es-extensions/store/asset/soapservice/asset.js
+++ b/modules/es-extensions/store/asset/soapservice/asset.js
@@ -159,10 +159,13 @@ asset.renderer = function(ctx){
                 if(page.meta.pageName === 'details'){
                     var config = require('/config/store.js').config();
                     var pluralType = 'wsdls';
+                    var domain = require('carbon').server.tenantDomain({tenantId:ctx.tenantId});
                     page.assets.downloadMetaData = {}; 
-                    page.assets.downloadMetaData.enabled = true;
-                    page.assets.downloadMetaData.downloadFileType = 'WSDL';
-                    page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.wsdl_uuid+'/content?tenantId='+ctx.tenantId;
+                    if(page.assets.wsdlContent){
+                        page.assets.downloadMetaData.enabled = true;
+                        page.assets.downloadMetaData.downloadFileType = 'WSDL';
+                        page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.wsdl_uuid+'/content?tenant='+domain;
+                    }
                 }
             }
         }

--- a/modules/es-extensions/store/asset/swagger/asset.js
+++ b/modules/es-extensions/store/asset/swagger/asset.js
@@ -191,10 +191,11 @@ asset.renderer = function(ctx){
                 if(page.meta.pageName === 'details'){
                     var config = require('/config/store.js').config();
                     var pluralType = 'swaggers';
+                    var domain = require('carbon').server.tenantDomain({tenantId:ctx.tenantId});
                     page.assets.downloadMetaData = {}; 
                     page.assets.downloadMetaData.enabled = true;
                     page.assets.downloadMetaData.downloadFileType = 'Swagger';
-                    page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenantId='+ctx.tenantId;
+                    page.assets.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenant='+domain;
                     page.assets.downloadMetaData.swaggerUrl = '/pages/swagger?path='+page.assets.path;
                 }
             }

--- a/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
@@ -8,7 +8,7 @@
 		<div class="btn-group" role="group" aria-label="...">
 		  <a class='btn btn-default' target='_blank' href='{{url ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
-		  <a class='btn btn-default' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
+		  <a class='btn btn-default' target='_blank' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
 		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
 		</div>
 	</div>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
@@ -92,10 +92,11 @@ asset.renderer = function(ctx) {
                     }
                     var config = require('/config/store.js').config();
                     var pluralType = page.rxt.pluralLabel.toLowerCase();
+                    var domain = require('carbon').server.tenantDomain({tenantId:ctx.tenantId});
                     page.downloadMetaData = {}; 
                     page.downloadMetaData.downloadFileType = page.rxt.singularLabel;
                     page.downloadMetaData.enabled = isDownloadable;
-                    page.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenantId='+ctx.tenantId;
+                    page.downloadMetaData.url = config.server.https+'/governance/'+pluralType+'/'+page.assets.id+'/content?tenant='+domain;
                 }
             }
         }

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/asset-download.hbs
@@ -7,7 +7,7 @@
 	<div class='col-md-4 col-md-4-offset-1'>
 		<div class="btn-group" role="group" aria-label="...">
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
-		  <a class='btn btn-default' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
+		  <a class='btn btn-default' target='_blank' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
 		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy to clipboard"}}' class="fw fw-copy" ></i> {{t "Copy to clipboard"}}</a>
 		</div>
 	</div>


### PR DESCRIPTION
This PR has the following changes:
- The download link opens in a new tab
- The tenantId in the URL has been replaced by tenant(uses the tenant domain)
- The SOAPSERVICE asset type no longer shows the download link if there is no WSDL