### PR TITLE
Fix for REGISTRY-3223

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/header.hbs
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/header.hbs
@@ -23,7 +23,11 @@
                 </div>
             </div>
             <div class="wr-auth pull-right">
+            {{#if cuser.isSuperTenant}}
                 <a class="auth-img" href="{{storeUrl}}" target="_blank">{{t "Go to Store"}}</a>
+            {{else}}
+                <a class="auth-img" href="{{storeUrl}}/t/{{cuser.tenantDomain}}" target="_blank">{{t "Go to Store"}}</a>
+            {{/if}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR changes the Go To Store link to be tenant aware. It will exhibit the following behaviour:
- Super tenant user : The link will not be tenant qualified (e.g. /store)
- Tenant user: The link will be tenant qualified (e.g. /store/t/wso2.com)

Addresses the issue: [REGISTRY-3323](https://wso2.org/jira/browse/REGISTRY-3323)