### PR TITLE
Fix for REGISTRY-3349

### DIFF
--- a/modules/es-extensions/store/asset/endpoint/asset.js
+++ b/modules/es-extensions/store/asset/endpoint/asset.js
@@ -17,6 +17,7 @@
  *
  */
 asset.manager = function(ctx) {
+    var tenantAPI = require('/modules/tenant-api.js').api;
     /**
      * The function augments the provided query to include published state information
      * @param  {[type]} query [description]
@@ -38,16 +39,12 @@ asset.manager = function(ctx) {
         return query;
     };
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
     return {
         //due to a bug needed to replicate the 'search' method. JIRA:https://wso2.org/jira/browse/STORE-561

--- a/modules/es-extensions/store/asset/policy/asset.js
+++ b/modules/es-extensions/store/asset/policy/asset.js
@@ -18,6 +18,7 @@
  */
 asset.manager = function(ctx) {
     var configs = require("/extensions/assets/policy/config/properties.json");
+    var tenantAPI = require('/modules/tenant-api.js').api;
     /**
      * The function augments the provided query to include published state information
      * @param  {[type]} query [description]
@@ -39,16 +40,12 @@ asset.manager = function(ctx) {
         return query;
     };
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
     var setCustomAssetAttributes = function(asset, userRegistry) {
         var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;

--- a/modules/es-extensions/store/asset/restservice/asset.js
+++ b/modules/es-extensions/store/asset/restservice/asset.js
@@ -17,6 +17,7 @@
  *
  */
 asset.manager = function(ctx) {
+    var tenantAPI = require('/modules/tenant-api.js').api;
     var setCustomAssetAttributes = function (asset, userRegistry) {
         var wadlUrl = asset.attributes.interface_wadl;
         if (wadlUrl != null) {
@@ -59,16 +60,12 @@ asset.manager = function(ctx) {
     };
 
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
 
     var getInterfaceTypeContent = function (resource) {

--- a/modules/es-extensions/store/asset/schema/asset.js
+++ b/modules/es-extensions/store/asset/schema/asset.js
@@ -18,6 +18,7 @@
  */
 asset.manager = function(ctx) {
     var configs = require("/extensions/assets/schema/config/properties.json");
+    var tenantAPI = require('/modules/tenant-api.js').api;
     /**
      * The function augments the provided query to include published state information
      * @param  {[type]} query [description]
@@ -39,16 +40,12 @@ asset.manager = function(ctx) {
         return query;
     };
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
     var setCustomAssetAttributes = function (asset, userRegistry){
         var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;

--- a/modules/es-extensions/store/asset/swagger/asset.js
+++ b/modules/es-extensions/store/asset/swagger/asset.js
@@ -17,17 +17,14 @@
  *
  */
 asset.manager = function(ctx) {    
+    var tenantAPI = require('/modules/tenant-api.js').api;
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
 
     var setCustomAssetAttributes = function(asset, userRegistry) {

--- a/modules/es-extensions/store/asset/wadl/asset.js
+++ b/modules/es-extensions/store/asset/wadl/asset.js
@@ -18,6 +18,7 @@
  */
 asset.manager = function(ctx) {
     var configs = require("/extensions/assets/wadl/config/properties.json");
+    var tenantAPI = require('/modules/tenant-api.js').api;
     /**
      * The function augments the provided query to include published state information
      * @param  {[type]} query [description]
@@ -39,16 +40,12 @@ asset.manager = function(ctx) {
         return query;
     };
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
     var setCustomAssetAttributes = function (asset, userRegistry){
         var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;

--- a/modules/es-extensions/store/asset/wsdl/asset.js
+++ b/modules/es-extensions/store/asset/wsdl/asset.js
@@ -18,6 +18,7 @@
  */
 asset.manager = function(ctx) {
   var configs = require("/extensions/assets/wsdl/config/properties.json");
+  var tenantAPI = require('/modules/tenant-api.js').api;
     /**
      * The function augments the provided query to include published state information
      * @param  {[type]} query [description]
@@ -39,16 +40,12 @@ asset.manager = function(ctx) {
         return query;
     };
     var getRegistry = function(cSession) {
-        var userMod = require('store').user;
-        var server = require('store').server;
-        var user = server.current(cSession);
-        var userRegistry;
-        if (user) {
-            userRegistry = userMod.userRegistry(cSession);
-        } else {
-            userRegistry = server.anonRegistry(tenantId);
+        var tenantDetails = tenantAPI.createTenantAwareAssetResources(cSession,{type:ctx.assetType});
+        if((!tenantDetails)&&(!tenantDetails.am)) {
+            log.error('The tenant-api was unable to create a registry instance by resolving tenant details');
+            throw 'The tenant-api  was unable to create a registry instance by resolving tenant details';
         }
-        return userRegistry;
+        return tenantDetails.am.registry;
     };
     var setCustomAssetAttributes = function(asset, userRegistry) {
         var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream;


### PR DESCRIPTION
This PR includes the following changes:
- The GREG asset extensions have been refactored to use the tenant-api provided by the ES Store
- This change ensures that the correct tenant's registry is used to retrieve assets

Addresses the following issue: [REGISTRY-3349](https://wso2.org/jira/browse/REGISTRY-3349)