### PR TITLE
Fix for REGISTRY-3366

### DIFF
--- a/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/restservice/themes/store/partials/asset-download.hbs
@@ -7,7 +7,7 @@
 	<div class='col-md-6'>
 		<div class="btn-group" role="group" aria-label="...">
 		  {{#if downloadMetaData.swaggerUrl}}
-		  <a class='btn btn-default' target='_blank' href='{{url ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
+		  <a class='btn btn-default' target='_blank' href='{{tenantedUrl ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
 		  {{/if}}
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
 		  <a class='btn btn-default' target='_blank' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>

--- a/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
+++ b/modules/es-extensions/store/asset/swagger/themes/store/partials/asset-download.hbs
@@ -6,7 +6,7 @@
 	{{#if downloadMetaData.enabled}}
 	<div class='col-md-6'>
 		<div class="btn-group" role="group" aria-label="...">
-		  <a class='btn btn-default' target='_blank' href='{{url ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
+		  <a class='btn btn-default' target='_blank' href='{{tenantedUrl ""}}{{downloadMetaData.swaggerUrl}}'><i class="fw fw-swagger"></i> {{t "Swagger UI"}}</a>
 		  <a style="display:none" id='download-link'>{{downloadMetaData.url}}</a>
 		  <a class='btn btn-default' target='_blank' href="{{downloadMetaData.url}}"><i class="fw fw-download"></i> {{t "Download"}}</a>
 		  <a class='btn btn-default' id='copy-button' data-clipboard-target="download-link"><i title='{{t "Copy URL"}}' class="fw fw-copy" ></i> {{t "Copy URL"}}</a>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/view-asset-diff-view-container.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/view-asset-diff-view-container.hbs
@@ -3,7 +3,7 @@
     {{#if ../assetVersions}}
         <div class="btn-group pull-right select" id="diff-view-version">
             <a class="btn btn-default btn-lg" id="diff-view-button"
-               href="{{url ""}}/pages/diff?type=wsdl&path={{../../assetVersions.0.path}},{{../path}}"
+               href="{{tenantedUrl ""}}/pages/diff?type=wsdl&path={{../../assetVersions.0.path}},{{../path}}"
                target="_blank">{{t "Compare with "}}
                 <span data-selected_base_path="{{../../assetVersions.0.path}}"
                       class="text-info selected"> {{../../assetVersions.0.version}} </span>
@@ -15,7 +15,7 @@
                 </button>
                 <ul class="dropdown-menu">
                     {{#each ../../../assetVersions}}
-                        <li><a target="_blank" href="{{url ""}}/pages/diff?type=wsdl&path={{this.path}},{{../path}}"
+                        <li><a target="_blank" href="{{tenantedUrl ""}}/pages/diff?type=wsdl&path={{this.path}},{{../path}}"
                                style="color: inherit" class="btn hover" data-base_path="{{../../path}}"
                                id="{{this.path}}">{{this.version}}</a></li>
                     {{/each}}

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/view-asset-top-common-addons-container.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/view-asset-top-common-addons-container.hbs
@@ -15,7 +15,7 @@
 
 <span class="asset-show-dependency">
         <a class="btn btn-default btn-lg pull-right"
-           href='{{url ""}}/pages/impact?path={{encodeURIComponent assets.path}}' target="_blank">
+           href='{{tenantedUrl ""}}/pages/impact?path={{encodeURIComponent assets.path}}' target="_blank">
             Show Dependency
         </a>
 </span>

--- a/modules/es-extensions/store/extensions/app/greg_impact/js/impactAnalysis.js
+++ b/modules/es-extensions/store/extensions/app/greg_impact/js/impactAnalysis.js
@@ -19,8 +19,7 @@
 /*
  * @set  default global variables
  */
-var svgIconsFolder = "../extensions/app/greg_impact/images/svg/",
-    footerHeight = 50,
+var footerHeight = 50,
     isSame = null,
     delay = 300,
     clicks = 0,

--- a/modules/es-extensions/store/extensions/app/greg_impact/pages/index.jag
+++ b/modules/es-extensions/store/extensions/app/greg_impact/pages/index.jag
@@ -20,6 +20,11 @@ require('/modules/store.js').exec(function (ctx) {
 
 var user = require('store').server.current(session);
 var log = new Log();
+var appAPI = require('rxt').app;
+var APP_CONTEXT = appAPI.getContext();
+var printAppContext = function(){
+    print(APP_CONTEXT);
+};
 
 /*
  * query parameters of the original request should be passed to the
@@ -131,25 +136,29 @@ if (!user) {
    	</div>
    	<!-- /#wrapper -->
 
-    <link href="../extensions/app/greg_impact/public/css/jquery-ui.css" rel="stylesheet" />
-    <link href="../extensions/app/greg_impact/public/css/select2.css" rel="stylesheet" />
-    <link href="../extensions/app/greg_impact/css/style.css" rel="stylesheet" />
-
-    <script src="../extensions/app/greg_impact/public/js/d3.v3.js"></script>
-    <script src="../extensions/app/greg_impact/public/js/jquery-1.11.1.js"></script>
-    <script src="../extensions/app/greg_impact/public/js/jquery-ui.js"></script>
-    <script src="../extensions/app/greg_impact/public/js/select2.js"></script>
+    <link href="<%printAppContext();%>/extensions/app/greg_impact/public/css/jquery-ui.css" rel="stylesheet" />
+    <link href="<%printAppContext();%>/extensions/app/greg_impact/public/css/select2.css" rel="stylesheet" />
+    <link href="<%printAppContext();%>/extensions/app/greg_impact/css/style.css" rel="stylesheet" />
+    <script>
+        var gc = {};
+        gc.context = '<%printAppContext();%>';
+        var svgIconsFolder = "<%printAppContext();%>/extensions/app/greg_impact/images/svg/";
+    </script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/d3.v3.js"></script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/jquery-1.11.1.js"></script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/jquery-ui.js"></script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/select2.js"></script>
     <!--[if lt IE 9]>
     <script src="../extensions/app/greg_impact/public/js/flashcanvas.js"></script>
     <![endif]-->
-	<script src="../extensions/app/greg_impact/public/js/rgbcolor.js"></script>
-    <script src="../extensions/app/greg_impact/public/js/StackBlur.js"></script>
-	<script src="../extensions/app/greg_impact/public/js/canvg.js"></script>
-	<script src="../extensions/app/greg_impact/public/js/svgenie.js"></script>
-	<script src="../extensions/app/greg_impact/public/js/jquery.inlineStyler.min.js"></script>
-    <script src="/publisher/themes/default/js/notify.min.js"></script>
-    <script src="/publisher/themes/default/js/messages.js"></script>
-    <script src="../extensions/app/greg_impact/js/impactAnalysis.js"></script>
+	<script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/rgbcolor.js"></script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/StackBlur.js"></script>
+	<script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/canvg.js"></script>
+	<script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/svgenie.js"></script>
+	<script src="<%printAppContext();%>/extensions/app/greg_impact/public/js/jquery.inlineStyler.min.js"></script>
+    <script src="<%printAppContext();%>/themes/store/js/notify.min.js"></script>
+    <script src="<%printAppContext();%>/themes/store/js/messages.js"></script>
+    <script src="<%printAppContext();%>/extensions/app/greg_impact/js/impactAnalysis.js"></script>
     <script>
 
         var imageScale = 0.9,

--- a/modules/es-extensions/store/extensions/app/greg_swagger/pages/index.jag
+++ b/modules/es-extensions/store/extensions/app/greg_swagger/pages/index.jag
@@ -29,6 +29,11 @@ require('/modules/store.js').exec(function (ctx) {
     var carbon = require('carbon');
     var config = require('/config/store.js').config();
     var permissionAPI = require('rxt').permissions;
+    var appAPI = require('rxt').app;
+    var APP_CONTEXT = appAPI.getContext();
+    var printAppContext = function(){
+      print(APP_CONTEXT);
+    };
 
     var ByteArrayInputStream = Packages.java.io.ByteArrayInputStream,
             commonConstants = Packages.org.wso2.carbon.registry.extensions.utils.CommonConstants;
@@ -91,22 +96,22 @@ require('/modules/store.js').exec(function (ctx) {
           <title>Swagger UI</title>
           <link rel="icon" type="image/png" href="../extensions/app/greg_swagger/images/favicon-32x32.png" sizes="32x32" />
           <link rel="icon" type="image/png" href="../extensions/app/greg_swagger/images/favicon-16x16.png" sizes="16x16" />
-          <link href='../extensions/app/greg_swagger/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-          <link href='../extensions/app/greg_swagger/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-          <link href='../extensions/app/greg_swagger/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-          <link href='../extensions/app/greg_swagger/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-          <link href='../extensions/app/greg_swagger/css/print.css' media='print' rel='stylesheet' type='text/css'/>
-          <script src='../extensions/app/greg_swagger/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/jquery.slideto.min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/handlebars-2.0.0.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/underscore-min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/backbone-min.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/js/swagger-ui.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/highlight.7.3.pack.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/marked.js' type='text/javascript'></script>
-          <script src='../extensions/app/greg_swagger/lib/swagger-oauth.js' type='text/javascript'></script>
+          <link href='<%printAppContext();%>/extensions/app/greg_swagger/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+          <link href='<%printAppContext();%>/extensions/app/greg_swagger/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+          <link href='<%printAppContext();%>/extensions/app/greg_swagger/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+          <link href='<%printAppContext();%>/extensions/app/greg_swagger/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+          <link href='<%printAppContext();%>/extensions/app/greg_swagger/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/jquery.slideto.min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/handlebars-2.0.0.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/underscore-min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/backbone-min.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/js/swagger-ui.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/marked.js' type='text/javascript'></script>
+          <script src='<%printAppContext();%>/extensions/app/greg_swagger/lib/swagger-oauth.js' type='text/javascript'></script>
 
           <script type="text/javascript">
             $(function () {


### PR DESCRIPTION
This PR includes the following changes:
- Swagger UI and Impact View resources (css,js, and images) are now accessible via tenanted URLs
- Swagger UI and Dependency View buttons are constructed using tenanted URLs depending on how the page is accessed 
   - If the details page is accessed using the tenanted URL the button links contain the tenant domain



Addresses the issue: [REGISTRY-3366](https://wso2.org/jira/browse/REGISTRY-3366)

Related PRs:
- https://github.com/wso2/carbon-store/pull/382