### PR TITLE
Fix for REGISTRY-3338

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/tags-container.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/tags-container.js
@@ -43,7 +43,6 @@ $(function () {
 
     $('#select-tags').select2({
         tags: true,
-        placeholder: 'NO TAGS FOUND',
         data: tags,
         multiple: true,
         cache: true


### PR DESCRIPTION
This PR removes the placeholder from the select2 plugin initialization.There is a known issue with the placeholder and IE 11 which causes the select2 dropdown to appear after setting tags [2].The root cause of the issue is related to IE 11 behaviour related to input fields with placeholders [1]:

*It all comes down how IE11 manages placeholders. In IE11 when an input field is focused, the placeholder is removed, causing the input event to fire.*

The tag drop down appears due to the input event firing.

**Reference**
[1] https://connect.microsoft.com/IE/feedback/details/885747/ie-11-fires-the-input-event-when-a-input-field-with-placeholder-is-focused
[2] https://github.com/select2/select2/issues/3300

Addresses the issue: [REGISTRY-3338](https://wso2.org/jira/browse/REGISTRY-3338)