### PR TITLE
Fix for REGISTRY-3343

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/tags-container.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/tags-container.js
@@ -45,7 +45,16 @@ $(function () {
         tags: true,
         data: tags,
         multiple: true,
-        cache: true
+        cache: true,
+        createTag:function(term){
+            //Prevent tags with spaces by replacing it with a dash (-)
+            var modifiedTerm = term.term.trim();
+            var formatted = modifiedTerm.split(' ').join('-');
+            return {
+                id:formatted,
+                text:formatted
+            };
+        }
     }).on("select2:select", function (e) {
         var data = {};
         data.tags = e.params.data.text;


### PR DESCRIPTION
This PR adds a formatting method to prevent users from entering spaces.Any tag which is entered with spaces is converted to a - (dash) delimited phrase.

Addresses the issue: [REGISTRY-3343](https://wso2.org/jira/browse/REGISTRY-3343)