### PR TITLE
Fix for REGISTRY-3472

### DIFF
--- a/modules/es-extensions/store/asset/restservice/asset.js
+++ b/modules/es-extensions/store/asset/restservice/asset.js
@@ -141,7 +141,8 @@ asset.configure = function () {
                 icon: 'fw fw-rest-service',
                 iconColor: 'purple'
             },
-            isDependencyShown: true
+            isDependencyShown: true,
+            isDiffViewShown:false
         }
     }
 };

--- a/modules/es-extensions/store/asset/soapservice/asset.js
+++ b/modules/es-extensions/store/asset/soapservice/asset.js
@@ -144,7 +144,8 @@ asset.configure = function() {
                 icon: 'fw fw-soap',
                 iconColor: 'orange'
             },
-            isDependencyShown: true
+            isDependencyShown: true,
+            isDiffViewShown:false
         }
     }
 };


### PR DESCRIPTION
Disabled the diff view for restservice and soapservice asset instances by using the isDiffViewEnabled property.

This property is by default set to true.

Addresses the following issue: [REGISTRY-3472](https://wso2.org/jira/browse/REGISTRY-3472)