### PR TITLE
Fix for REGISTRY-3368

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-diff-api/apis/governance-artifacts.jag
+++ b/modules/es-extensions/store/extensions/app/greg-diff-api/apis/governance-artifacts.jag
@@ -6,6 +6,11 @@
     var DIFF_TEXT = 'diff-text';
     var req = ctx.request;
     var uriMatcher = new URIMatcher(req.getRequestURI());
+    var MultitenantConstants = Packages.org.wso2.carbon.base.MultitenantConstants;
+    var carbon = require('carbon');
+    var store = require('store');
+    var user = store.server.current(session);
+    var username = user ? user.username : carbon.user.anonUser;
     var options = uriMatcher.match(pattern) || {};
     if (!options.action) {
         response.sendError(404);
@@ -18,14 +23,22 @@
     var base_path = resourcePaths[0];
     var new_path = resourcePaths[1];
     var media_type = qParams.type;
+    var tenantDomain = qParams.tenant ?  qParams.tenant : MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+    var tenantId = carbon.server.tenantId({domain:tenantDomain});
+    options.tenantId = tenantId;
+    options.username = username;
 
     //Resolve the method to use
     switch (options.action) {
         case DIFF_DETAIL:
-            diffAPI.getDetailsDiff(base_path, new_path, media_type);
+            store.server.sandbox(options,function(){
+                diffAPI.getDetailsDiff(base_path, new_path, media_type,tenantId);
+            });
             break;
         case DIFF_TEXT:
-            diffAPI.getTextDiff(base_path, new_path);
+            store.server.sandbox(options,function(){
+                diffAPI.getTextDiff(base_path, new_path,tenantId);
+            });
             break;
         default:
             log.error('Action: ' + options.action + ' not supported');

--- a/modules/es-extensions/store/extensions/app/greg-diff/themes/store/code/greg-diff-meta.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-diff/themes/store/code/greg-diff-meta.hbs
@@ -1,4 +1,6 @@
-<!--<script>-->
-    <!--diffView = {};-->
-    <!--diffView.content = '{{dump diffContent}}';-->
-<!--</script>-->
+<script>
+    if(!store.store){
+       store.store = {};
+    }
+    store.store.tenantDomain = '{{cuser.tenantDomain}}';
+</script>

--- a/modules/es-extensions/store/extensions/app/greg-diff/themes/store/helpers/diff-base.js
+++ b/modules/es-extensions/store/extensions/app/greg-diff/themes/store/helpers/diff-base.js
@@ -19,9 +19,8 @@
 var resources = function () {
     return {
         css: ['ambiance.css', 'codemirror.css', 'merge.css', 'diff.css'],
-        //code:['greg-association-meta.hbs'],
+        code: ['greg-diff-meta.hbs'],
         js: ['codemirror.js', 'css.js', 'diff_match_patch.js', 'htmlmixed.js', 'javascript.js', 'jquery-ui.js',
-            'diff.js', 'merge.js', 'xml.js', 'diff-api.js'],
-        code: ['greg-diff-meta.hbs']
+            'diff.js', 'merge.js', 'xml.js', 'diff-api.js']
     }
 };

--- a/modules/es-extensions/store/extensions/app/greg-diff/themes/store/js/diff-api.js
+++ b/modules/es-extensions/store/extensions/app/greg-diff/themes/store/js/diff-api.js
@@ -15,81 +15,120 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-var diffData = {};
-// Get full diff with two resources
-function getUrlParameter(sParam) {
-    var sPageURL = window.location.search.substring(1);
-    var sURLVariables = sPageURL.split('&');
-    for (var i = 0; i < sURLVariables.length; i++) {
-        var sParameterName = sURLVariables[i].split('=');
-        if (sParameterName[0] == sParam) {
-            return sParameterName[1];
+$(document).ready(function() {
+    var paths = getUrlParameter('path').split(',');
+    var type = getUrlParameter('type');
+    var domain = resolveDomain();
+    var url = resolveURL(paths, domain);
+    init(url);
+
+    /**
+     * Load the diff view data asynchoronously and render the UI
+     */
+    function init(url) {
+        $.ajax({
+            url: url,
+            type: 'GET',
+            async: false,
+            success: function(response) {
+                var diffData = JSON.parse(response);
+                //Note: We do not need to call the render method here (since this is async), however in the future 
+                //if we need to load the diff view asynchronously the async property can be set to TRUE.
+                render(diffData); 
+            },
+            error: function() {
+                alert('Failed to load comparison data');
+            }
+        });
+    }
+    /**
+     * Resolves the tenant domain against which the API call must be made
+     */
+    function resolveDomain() {
+        var tenantDomain;
+        var domain = '';
+        if ((store) && (store.store)) {
+            tenantDomain = store.store.tenantDomain;
+        }
+        //Construct the tenant query parameter if a tenant domain was resolved
+        if (tenantDomain) {
+            domain = '&tenant=' + tenantDomain;
+        }
+        return domain;
+    }
+
+    function resolveURL(paths, domain) {
+        return caramel.context + '/apis/governance-artifacts/diff-text?targets=' + paths[1] + ',' + paths[0] + domain;
+    }
+
+    function getUrlParameter(sParam) {
+        var sPageURL = window.location.search.substring(1);
+        var sURLVariables = sPageURL.split('&');
+        for (var i = 0; i < sURLVariables.length; i++) {
+            var sParameterName = sURLVariables[i].split('=');
+            if (sParameterName[0] == sParam) {
+                return sParameterName[1];
+            }
         }
     }
-}
-
-var paths = getUrlParameter('path').split(',');
-var type = getUrlParameter('type');
-
-$.ajax({
-    url: caramel.context + '/apis/governance-artifacts/diff-text?targets=' + paths[1] + ',' + paths[0],
-    type: 'GET',
-    async: false,
-    success: function (response) {
-        diffData = JSON.parse(response);
-    },
-    error: function () {
-        //console.log("Error getting content.");
+    /**
+     * Renders the diff view by processing the response provided by the API
+     * and then initializing the CodeMirror UI
+     */
+    function render(diffData) {
+        var opts = {};
+        var init_section_name;
+        var init_change_name;
+        var initialLoadContent;
+        opts.value = null;
+        opts.orig1 = null;
+        opts.orig2 = null;
+        opts.dv = null;
+        opts.panes = 2;
+        opts.highlight = true;
+        opts.connect = null;
+        opts.collapse = false;
+        var sections = diffData.sections;
+        //Process the diff object sent by the API
+        if (!jQuery.isEmptyObject(sections)) {
+            for (var key in sections) {
+                init_section_name = key;
+                break;
+            }
+            if (!jQuery.isEmptyObject(sections[init_section_name].content)) {
+                for (var key2 in sections[init_section_name].content) {
+                    init_change_name = key2;
+                    break;
+                }
+                if (!jQuery.isEmptyObject(diffData.sections[init_section_name].content[init_change_name])) {
+                    initialLoadContent = diffData.sections[init_section_name].content[init_change_name][0];
+                }
+            }
+        }
+        opts.initialLoadContent = initialLoadContent;
+        opts.value = document.documentElement.innerHTML;
+        opts.orig2 = initialLoadContent.content.changed;
+        initUI(opts);
+        setViewPanelsHeight();
+        addTitle();
+    }
+    /**
+     * Initializing logic for the CodeMirror librray
+     */
+    function initUI(options) {
+        if (options.value == null) return;
+        var target = document.getElementById("diffView");
+        target.innerHTML = "";
+        dv = CodeMirror.MergeView(target, {
+            value: options.initialLoadContent.content.original,
+            origLeft: options.panes == 3 ? options.orig1 : null,
+            orig: options.orig2,
+            lineNumbers: true,
+            mode: "text/xml",
+            highlightDifferences: options.highlight,
+            connect: options.connect,
+            collapseIdentical: options.collapse,
+            theme: "base16-light"
+        });
     }
 });
-
-// Getting initial load data
-var sections = diffData.sections;
-var init_section_name, init_change_name, initialLoadContent;
-
-if (!jQuery.isEmptyObject(sections)) {
-
-    for (var key in sections) {
-        init_section_name = key;
-        break;
-    }
-
-    if (!jQuery.isEmptyObject(sections[init_section_name].content)) {
-        for (var key2 in sections[init_section_name].content) {
-            init_change_name = key2;
-            break;
-        }
-        if (!jQuery.isEmptyObject(diffData.sections[init_section_name].content[init_change_name])) {
-            initialLoadContent = diffData.sections[init_section_name].content[init_change_name][0];
-        }
-    }
-}
-
-var value, orig1, orig2, dv, panes = 2, highlight = true, connect = null, collapse = false;
-
-function initUI() {
-    if (value == null) return;
-    var target = document.getElementById("diffView");
-    target.innerHTML = "";
-    dv = CodeMirror.MergeView(target, {
-        value: initialLoadContent.content.original,
-        origLeft: panes == 3 ? orig1 : null,
-        orig: orig2,
-        lineNumbers: true,
-        mode: "text/xml",
-        highlightDifferences: highlight,
-        connect: connect,
-        collapseIdentical: collapse,
-        theme: "base16-light"
-    });
-}
-
-// Setting initial load data.
-window.onload = function () {
-    value = document.documentElement.innerHTML;
-    orig2 = initialLoadContent.content.changed;
-    initUI();
-    setViewPanelsHeight();
-    addTitle();
-};
-


### PR DESCRIPTION
This PR contains the following changes:
- The diff view API has been re-factored to utilize a tenant flow when loading diffs 
- The diff view API must be called with the tenant domain (if one is not provided it is assumed that the call is made for the carbon.super tenant domain)
- The client side scripts receive the tenant domain via the store.store.tenantDomain attribute
- The client side diff view code has been re-factored to support asynchronous loading 
 

Addresses the issue: [REGISTRY-3368](https://wso2.org/jira/browse/REGISTRY-3368)