### PR TITLE
REGISTRY-3491 :  fix

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/notes-api.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/js/notes-api.js
@@ -68,8 +68,7 @@ $(function () {
                     });
                     $('#add-note-content').val('');
                 messages.alertSuccess("Note added successfully");
-                setTimeout(function(){location.reload(true);},2000);
-                location.reload(true);
+                setTimeout(function(){location.reload(true);},3000);
             },
             error: function () {
                 //console.log("Error adding a note.");


### PR DESCRIPTION
The use of location.relaod(true) twice makes it not appear in IE11 due to some page rendering issue.
Further the setTimeout method already calls the location.reload method. SO no point of calling it twice.
Therfore removed the additional location.reload method.