### PR TITLE
Fix for REGISTRY-3439: Change the  side panel icon arrow style in store

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/js/sidepanel.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/js/sidepanel.js
@@ -97,14 +97,14 @@ function toggleSidePanel(view,button){
     $(button).toggleClass('selected');
 
     if($(button).hasClass('selected')){
-        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').removeClass('fw-left-arrow');
-        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').addClass('fw-right-arrow');
+        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').removeClass('fw-left');
+        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').addClass('fw-right');
         $(sidePanel).show();
         $(sidePanel).addClass('toggled');
     }
     else {
-        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').removeClass('fw-right-arrow');
-        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').addClass('fw-left-arrow');
+        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').removeClass('fw-right');
+        $('.top-menu-right-custom  .fw-stack-md  .fw-stack-1-5x').addClass('fw-left');
         $(sidePanel).hide();
         $(sidePanel).removeClass('toggled');
     }

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -97,7 +97,7 @@
                             {{#hasAppPermission . key="GREG_COMMUNITY_FEATURES" username=cuser.username tenantId=cuser.tenantId}}
                                 <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)" class="cu-btn wr-side-panel-toggle-btn">
                                 <span class="fw-stack-md">
-                                    <i class="fw fw-left-arrow fw-stack-1-5x"></i>
+                                    <i style="padding-bottom: 4pt" class="fw fw-left fw-stack-1-5x"></i>
                                 </span>
                                     Options
                                 </a>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/ribbon.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/ribbon.hbs
@@ -44,7 +44,7 @@
                             </a>
                             <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)" class="cu-btn wr-side-panel-toggle-btn">
                             <span class="fw-stack-md">
-                                <i class="fw fw-left-arrow fw-stack-1-5x"></i>
+                                <i style="padding-bottom: 4pt" class="fw fw-left fw-stack-1-5x"></i>
                             </span>
                                 Options
                             </a>


### PR DESCRIPTION
In this PR I have: 
Changed the arrow style in store side options panel with the latest font-wso2 styling class , The issue here is, in both publisher and store use the same [FW](http://wso2-dev-ux.github.io/font-wso2/icons.html) (Font-WSO2) classes but their versions are different. In the above-attached screenshots, left side(Publisher side) arrow styling(`fw-left-arrow`) has changed in the new FW library and there is a new class for the same arrow style(`fw-left`).
So we have to update the FW library in publisher side and It might change the intended styling
