### PR TITLE
improving G-Reg publisher dependency visualization feature

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg_impact/js/impactAnalysis.js
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/js/impactAnalysis.js
@@ -813,8 +813,37 @@ function showRelations(d){
  * Function to save current screen as a .png image file.
  */
 function svgDownload(){
-    $(graphSVG).clone().appendTo("#graph-capture");
-    $(graphCaptureSVG).attr("id","cloned");
+    var minX = Number.POSITIVE_INFINITY, 
+        minY = Number.POSITIVE_INFINITY,
+        currentScale = zoom.scale();
+
+    d3.selectAll("[group=node]").each(function(){
+        console.log(this);
+        var xforms = this.getAttribute('transform');
+        var parts  = /translate\(\s*([^\s,)]+)[ ,]([^\s,)]+)/.exec(xforms);
+        var firstX = parseInt(parts[1], 10),
+            firstY = parseInt(parts[2], 10);
+        if (firstX < minX)
+            minX = firstX;
+        if (firstY <minY)
+            minY = firstY;
+    });
+    minX = -minX +100;
+    minY = -minY +100;
+
+   var graphBBox = d3.select("svg g#mainG").node().getBBox();
+
+    var clone = $(graphSVG).clone();
+    clone.appendTo("#graph-capture");
+    clone.attr("id","cloned");
+    clone.attr("width", (graphBBox.width + 200) * currentScale);
+    clone.attr("height", (graphBBox.height + 100) * currentScale);
+    clone.attr("viewBox", [
+        0,
+        0,
+        (graphBBox.width + 200) * currentScale,
+        (graphBBox.height + 100) * currentScale
+      ].join(" "));
     var cssRules = {
         'propertyGroups' : {
             'block' : ['fill'],
@@ -829,7 +858,10 @@ function svgDownload(){
             'headings' : ['text']
         }
     };
-    $(graphCaptureSVG + " g").inlineStyler(cssRules);
+    var g = clone.children("g");
+    g.attr('transform','translate('+minX*currentScale+','+minY*currentScale+')'+' scale('+currentScale+')');
+    g.inlineStyler(cssRules);
+
     svgenie.save(document.getElementById("cloned"), { name:DOWNLOAD_FILENAME+'.png' });
     $(graphCaptureSVG).remove();
 }

--- a/modules/es-extensions/publisher/extensions/app/greg_impact/public/js/svgenie.js
+++ b/modules/es-extensions/publisher/extensions/app/greg_impact/public/js/svgenie.js
@@ -65,12 +65,8 @@ var svgenie = (function(){
         };
 
         // IE10
-        if( window.navigator.msSaveBlob ){
-            conf.canvas.toBlob( function ( blobby ){
-                if( window.navigator.msSaveBlob ){
-                    window.navigator.msSaveBlob( blobby, conf.name );
-                }
-            }, "image/png" );
+        if (window.navigator.msSaveOrOpenBlob) {
+            navigator.msSaveOrOpenBlob(conf.canvas.msToBlob(), conf.name);
             return;
         }
 


### PR DESCRIPTION
With [1] user's can download the graph image in IE 10+.
With [2] downloaded image will contain the complete graph with the selected zoom level.
However the maximum size of the image downloadable may vary depending on the browser type.

[1] https://wso2.org/jira/browse/REGISTRY-3601
[2] https://wso2.org/jira/browse/REGISTRY-2961