### PR TITLE
REGISTRY-3532, 3577, 3579 Improving Rest Service handling capability in Governance Center

### DIFF
--- a/modules/distribution/src/main/resources/carbon-home/conf/registry.xml
+++ b/modules/distribution/src/main/resources/carbon-home/conf/registry.xml
@@ -141,6 +141,20 @@
         </filter>
     </handler>
 
+    <!-- This handler processes the rest services being added to the registry -->
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.RESTServiceMediaTypeHandler" profiles="default,uddi-registry">
+        <property name="swaggerLocationConfiguration" type="xml">
+            <location>/apimgt/applicationdata/api-docs/</location>
+        </property>
+        <property name="wadlLocationConfiguration" type="xml">
+            <location>/trunk/wadls/</location>
+        </property>
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.wso2-restservice+xml</property>
+        </filter>
+    </handler>
+
     <!--This handler will delete resources individually when deleting a collection of resources-->
 
     <handler class="org.wso2.carbon.registry.extensions.handlers.RecursiveDeleteHandler">

--- a/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceCreationTestCase.java
+++ b/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceCreationTestCase.java
@@ -135,7 +135,7 @@ public class RESTServiceCreationTestCase extends GREGIntegrationBaseTest {
         artifact.setAttribute("overview_context", "/rs_test");
         artifact.setAttribute("overview_version", "1.1.1");
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
         artifact.setAttribute("overview_description", "Description");
 
         artifactManager.addGenericArtifact(artifact);
@@ -161,7 +161,7 @@ public class RESTServiceCreationTestCase extends GREGIntegrationBaseTest {
         artifact.setAttribute("overview_context", "/rs_test");
         artifact.setAttribute("overview_version", "1.1.1");
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
         artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
         artifact.setAttribute("overview_description", "Description");
 
@@ -239,7 +239,7 @@ public class RESTServiceCreationTestCase extends GREGIntegrationBaseTest {
         artifact.setAttribute("overview_context", "/rs_test");
         artifact.setAttribute("overview_version", "1.4.1");
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
         artifact.setAttribute("endpoints_entry", "None:http://test.org");
 
         artifactManager.addGenericArtifact(artifact);

--- a/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceCreationTestCase.java
+++ b/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceCreationTestCase.java
@@ -1,0 +1,336 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.registry.metadata.test.restservice;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.governance.api.exception.GovernanceException;
+import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
+import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
+import org.wso2.carbon.governance.api.util.GovernanceUtils;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.registry.ws.client.registry.WSRegistryServiceClient;
+import org.wso2.greg.integration.common.utils.GREGIntegrationBaseTest;
+import org.wso2.greg.integration.common.utils.RegistryProviderUtil;
+
+import javax.xml.namespace.QName;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class RESTServiceCreationTestCase extends GREGIntegrationBaseTest {
+    private GenericArtifactManager artifactManager;
+    private Registry registry;
+
+    /**
+     * This method used to init the REST Service addition test cases.
+     *
+     * @throws Exception
+     */
+    @BeforeClass(groups = { "wso2.greg" }, alwaysRun = true)
+    public void init() throws Exception {
+        super.init(TestUserMode.SUPER_TENANT_ADMIN);
+        WSRegistryServiceClient wsRegistryServiceClient = new RegistryProviderUtil().getWSRegistry(automationContext);
+
+        registry = new RegistryProviderUtil().getGovernanceRegistry(wsRegistryServiceClient, automationContext);
+        GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry,
+                GovernanceUtils.findGovernanceArtifactConfigurations(registry));
+        artifactManager = new GenericArtifactManager(registry, "restservice");
+
+    }
+
+    /**
+     * Creates a REST service using generic artifact.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "create REST Service using GenericArtifact")
+    public void createRESTService() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("org.wso2.test", "RESTService1"));
+
+        artifact.setAttribute("overview_name", "RESTService1");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "4.5.0");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertEquals(artifact.getAttribute("overview_name"), receivedArtifact.getAttribute("overview_name"),
+                " Service name must be equal");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    @Test(groups = { "wso2.greg" }, description = "try add REST service without version",
+            dependsOnMethods = "createRESTService", expectedExceptions = GovernanceException.class)
+    public void createRESTServiceFault() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService2"));
+
+        artifact.setAttribute("overview_name", "RESTService2");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertEquals(artifact.getAttribute("overview_name"), receivedArtifact.getAttribute("overview_name"),
+                " Service name must be equal");
+    }
+
+    /**
+     * Create rest service artifact including swagger url. expected to be having 2 associations for the created
+     * service which are swagger resource and the endpoint created.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service including swagger url")
+    public void createRESTServiceWithSwagger() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService2"));
+
+        artifact.setAttribute("overview_name", "RESTService2");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "4.5.0");
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Swagger and Endpoint");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including wadl url. expected to be having 2 associations for the created
+     * service which are wadl document and the endpoint created.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service including wadl url")
+    public void createRESTServiceWithWadl() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService3"));
+
+        artifact.setAttribute("overview_name", "RESTService3");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.1.1");
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : WADL and Endpoint");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including both swagger and wadl urls. expected to be having 4 associations
+     * for the created service which are swagger and wadl resources and the 2 endpoint created.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service including wadl and swagger urls")
+    public void createRESTServiceWithWadlAndSwagger() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService3"));
+
+        artifact.setAttribute("overview_name", "RESTService3");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.1.1");
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 4,
+                "Expecting 4 dependencies : WADL, swagger and and 2 endpoints");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including an endpoint.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service with endpoints.")
+    public void createRESTServiceWithEndpoints() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService4"));
+
+        artifact.setAttribute("overview_name", "RESTService4");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.0.1");
+        artifact.setAttribute("endpoints_entry", "None:http://test.org");
+        artifact.setAttribute("endpoints_entry", ":http://test.org");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 1, "Expecting 1 endpoint dependencies.");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including swagger url and an endpoint. expected to be having 3 associations
+     * for the created service which are swagger resource and the endpoint created and also the endpoint added manually.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service with endpoints and swagger.")
+    public void createRESTServiceWithEndpointsAndSwagger() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService5"));
+
+        artifact.setAttribute("overview_name", "RESTService5");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.0.1");
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+        artifact.setAttribute("endpoints_entry", "None:http://test.org");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 3, "Expecting 2 endpoint dependencies and swagger.");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including wadl url and an endpoint. expected to be having 3 associations
+     * for the created service which are wadl resource and the endpoint created and also the endpoint added manually.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+
+    @Test(groups = { "wso2.greg" }, description = "add REST service with endpoints and wadl")
+    public void createRESTServiceWithEndpointsAndWadl() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService6"));
+
+        artifact.setAttribute("overview_name", "RESTService6");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.4.1");
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+        artifact.setAttribute("endpoints_entry", "None:http://test.org");
+
+        artifactManager.addGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 3, "Expecting 3 endpoint dependencies and swagger.");
+
+        artifactManager.removeGenericArtifact(artifact.getId());
+    }
+
+    /**
+     * Create rest service artifact including an invalid swagger url. Expected to throw an exception.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+    @Test(groups = { "wso2.greg" }, description = "add REST service with invalid swagger url.",
+            expectedExceptions = GovernanceException.class)
+    public void createRESTServiceWithInvalidSwaggerUrl() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService7"));
+
+        artifact.setAttribute("overview_name", "RESTService7");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.4.1");
+        artifact.setAttribute("interface_swagger", "http://wso2.com/");
+
+        try {
+            artifactManager.addGenericArtifact(artifact);
+        } catch (RegistryException e) {
+            throw new GovernanceException(e);
+        }
+    }
+
+    /**
+     * Create rest service artifact including an invalid wadl url. Expected to throw an exception.
+     *
+     * @throws GovernanceException If fails to create the rest service.
+     */
+
+    @Test(groups = { "wso2.greg" }, description = "add REST service with invalid wadl url.",
+            expectedExceptions = GovernanceException.class)
+    public void createRESTServiceWithInvalidWadlUrl() throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("RESTService7"));
+
+        artifact.setAttribute("overview_name", "RESTService7");
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "1.4.1");
+        artifact.setAttribute("interface_wadl", "http://wso2.com/");
+
+        try {
+            artifactManager.addGenericArtifact(artifact);
+        } catch (RegistryException e) {
+            throw new GovernanceException(e);
+        }
+    }
+
+    /**
+     * Cleans up resources after the tests finishes.
+     *
+     * @throws GovernanceException
+     */
+    @AfterClass(groups = { "wso2.greg" })
+    public void cleanup() throws GovernanceException {
+        try {
+            GenericArtifactManager genericArtifactManager = new GenericArtifactManager(registry, "restservice");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "swagger");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "wadl");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "endpoint");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "schema");
+            deleteResources(genericArtifactManager);
+        } catch (RegistryException e) {
+            throw new GovernanceException("Error in cleaning up resources. GenericArtifactManager cannot be created. ", e);
+        } finally {
+            artifactManager = null;
+        }
+    }
+
+    /**
+     * Removes created resources from the registry
+     *
+     * @param genericArtifactManager    generic artifact manager
+     * @throws GovernanceException      If fails to remove resources
+     */
+    private void deleteResources(GenericArtifactManager genericArtifactManager) throws GovernanceException {
+        GenericArtifact[] genericArtifacts = genericArtifactManager.getAllGenericArtifacts();
+        for(GenericArtifact genericArtifact : genericArtifacts) {
+            genericArtifactManager.removeGenericArtifact(genericArtifact);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceUpdateTestCase.java
@@ -1,0 +1,273 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.registry.metadata.test.restservice;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.governance.api.exception.GovernanceException;
+import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
+import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
+import org.wso2.carbon.governance.api.util.GovernanceUtils;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.registry.ws.client.registry.WSRegistryServiceClient;
+import org.wso2.greg.integration.common.utils.GREGIntegrationBaseTest;
+import org.wso2.greg.integration.common.utils.RegistryProviderUtil;
+
+import javax.xml.namespace.QName;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
+    private GenericArtifactManager artifactManager;
+    private Registry registry;
+
+    /**
+     * This method used to init the REST Service addition test cases.
+     *
+     * @throws Exception
+     */
+    @BeforeClass(groups = { "wso2.greg" }, alwaysRun = true)
+    public void init() throws Exception {
+        super.init(TestUserMode.SUPER_TENANT_ADMIN);
+        WSRegistryServiceClient wsRegistryServiceClient = new RegistryProviderUtil().getWSRegistry(automationContext);
+
+        registry = new RegistryProviderUtil().getGovernanceRegistry(wsRegistryServiceClient, automationContext);
+        GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry,
+                GovernanceUtils.findGovernanceArtifactConfigurations(registry));
+        artifactManager = new GenericArtifactManager(registry, "restservice");
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a swagger url.
+     * Expected to have two dependencies after update.
+     *
+     * @throws GovernanceException
+     */
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add swagger url")
+    public void updateRESTServiceWithSwagger() throws GovernanceException {
+        String artifactId = createArtifact("RestService1");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Swagger and Endpoint");
+
+        artifactManager.removeGenericArtifact(artifactId);
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a wadl url.
+     * Expected to have two dependencies after update.
+     *
+     * @throws GovernanceException
+     */
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add wadl url")
+    public void updateRESTServiceWithWadl() throws GovernanceException {
+        String artifactId = createArtifact("RestService2");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_swagger", "");
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Wadl and Endpoint");
+
+        artifactManager.removeGenericArtifact(artifactId);
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a swagger and a wadl url.
+     * Expected to have four dependencies after update.
+     *
+     * @throws GovernanceException
+     */
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add both swagger and wadl url.")
+    public void updateRESTServiceWithWadlAndSwagger() throws GovernanceException {
+        String artifactId = createArtifact("RestService3");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 4, "Expecting 2 dependencies : Wadl and Endpoint");
+
+        artifactManager.removeGenericArtifact(artifactId);
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a swagger url.
+     * After that revert the change. Expected to be back to the previous state.
+     *
+     * @throws GovernanceException
+     */
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add swagger and then remove.")
+    public void updateRESTServiceAddSwaggerAndRemove() throws GovernanceException {
+        String artifactId = createArtifact("RestService4");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Swagger and Endpoint");
+
+        receivedArtifact.removeAttribute("interface_swagger");
+
+        artifactManager.updateGenericArtifact(receivedArtifact);
+
+        receivedArtifact = artifactManager.getGenericArtifact(receivedArtifact.getId());
+        assertEquals(receivedArtifact.getDependencies().length, 0, "All dependencies should have been removed.");
+
+        artifactManager.removeGenericArtifact(receivedArtifact.getId());
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a wadl url.
+     * After that revert the change. Expected to be back to the previous state.
+     *
+     * @throws GovernanceException
+     */
+
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add wadl and then remove.")
+    public void updateRESTServiceAddWadlAndRemove() throws GovernanceException {
+        String artifactId = createArtifact("RestService5");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Wadl and Endpoint");
+
+        receivedArtifact.removeAttribute("interface_wadl");
+
+        artifactManager.updateGenericArtifact(receivedArtifact);
+
+        receivedArtifact = artifactManager.getGenericArtifact(receivedArtifact.getId());
+        assertEquals(receivedArtifact.getDependencies().length, 0, "All dependencies should have been removed.");
+
+        artifactManager.removeGenericArtifact(receivedArtifact.getId());
+    }
+
+    /**
+     * Creates an rest service without any interface urls and then update it by adding a wadl url.
+     * Then again update it by adding a swagger url. Expected to be have 4 dependencies after the second update.
+     *
+     * @throws GovernanceException
+     */
+
+    @Test(groups = { "wso2.greg" }, description = "Update REST Service add wadl and then add swagger.")
+    public void updateRESTServiceAddWadlAndSwagger() throws GovernanceException {
+        String artifactId = createArtifact("RestService6");
+        GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
+        artifact.setAttribute("interface_wadl",
+                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+
+
+        artifactManager.updateGenericArtifact(artifact);
+
+        GenericArtifact receivedArtifact = artifactManager.getGenericArtifact(artifact.getId());
+        assertNotNull(receivedArtifact.getDependencies());
+        assertEquals(receivedArtifact.getDependencies().length, 2, "Expecting 2 dependencies : Wadl and Endpoint");
+
+        receivedArtifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
+
+        artifactManager.updateGenericArtifact(receivedArtifact);
+
+        receivedArtifact = artifactManager.getGenericArtifact(receivedArtifact.getId());
+        assertEquals(receivedArtifact.getDependencies().length, 4,
+                "Expecting 4 dependencies : Wadl Swagger and 2 Endpoints");
+
+        artifactManager.removeGenericArtifact(receivedArtifact.getId());
+    }
+
+    /**
+     * Cleans up resources after the tests finishes.
+     *
+     * @throws GovernanceException
+     */
+    @AfterClass(groups = { "wso2.greg" })
+    public void cleanup() throws GovernanceException {
+        try {
+            GenericArtifactManager genericArtifactManager = new GenericArtifactManager(registry, "restservice");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "wadl");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "swagger");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "endpoint");
+            deleteResources(genericArtifactManager);
+            genericArtifactManager = new GenericArtifactManager(registry, "schema");
+            deleteResources(genericArtifactManager);
+        } catch (RegistryException e) {
+            throw new GovernanceException("Error in cleaning up resources. GenericArtifactManager cannot be created. ", e);
+        } finally {
+            artifactManager = null;
+        }
+    }
+
+    /**
+     * Creates an rest service artifact and adds to the registry.
+     *
+     * @param serviceName           service name.
+     * @return                      artifact id.
+     * @throws GovernanceException  If fails to create a rest service artifact.
+     */
+    private String createArtifact(String serviceName) throws GovernanceException {
+        GenericArtifact artifact = artifactManager.newGovernanceArtifact(new QName("org.wso2.test", serviceName));
+
+        artifact.setAttribute("overview_name", serviceName);
+        artifact.setAttribute("overview_context", "/rs_test");
+        artifact.setAttribute("overview_version", "4.5.0");
+        artifact.setAttribute("overview_description", "Description");
+
+        artifactManager.addGenericArtifact(artifact);
+        return artifact.getId();
+    }
+
+    /**
+     * Removes created resources from the registry
+     *
+     * @param genericArtifactManager    generic artifact manager
+     * @throws GovernanceException      If fails to remove resources
+     */
+    private void deleteResources(GenericArtifactManager genericArtifactManager) throws GovernanceException {
+        GenericArtifact[] genericArtifacts = genericArtifactManager.getAllGenericArtifacts();
+        for(GenericArtifact genericArtifact : genericArtifacts) {
+            genericArtifactManager.removeGenericArtifact(genericArtifact);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/java/org/wso2/carbon/registry/metadata/test/restservice/RESTServiceUpdateTestCase.java
@@ -89,7 +89,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
         artifact.setAttribute("interface_swagger", "");
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
 
         artifactManager.updateGenericArtifact(artifact);
 
@@ -112,7 +112,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
         artifact.setAttribute("interface_swagger", "http://petstore.swagger.io/v2/swagger.json");
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
 
         artifactManager.updateGenericArtifact(artifact);
 
@@ -125,7 +125,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
 
     /**
      * Creates an rest service without any interface urls and then update it by adding a swagger url.
-     * After that revert the change. Expected to be back to the previous state.
+     * After that revert the change. Expected to have the endpoint artifact but not the swagger document.
      *
      * @throws GovernanceException
      */
@@ -146,14 +146,14 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         artifactManager.updateGenericArtifact(receivedArtifact);
 
         receivedArtifact = artifactManager.getGenericArtifact(receivedArtifact.getId());
-        assertEquals(receivedArtifact.getDependencies().length, 0, "All dependencies should have been removed.");
+        assertEquals(receivedArtifact.getDependencies().length, 1, "Only endpoint dependency is expected.");
 
         artifactManager.removeGenericArtifact(receivedArtifact.getId());
     }
 
     /**
      * Creates an rest service without any interface urls and then update it by adding a wadl url.
-     * After that revert the change. Expected to be back to the previous state.
+     * After that revert the change. Expected to have the endpoint artifact but not the wadl document.
      *
      * @throws GovernanceException
      */
@@ -163,7 +163,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         String artifactId = createArtifact("RestService5");
         GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
 
 
         artifactManager.updateGenericArtifact(artifact);
@@ -177,7 +177,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         artifactManager.updateGenericArtifact(receivedArtifact);
 
         receivedArtifact = artifactManager.getGenericArtifact(receivedArtifact.getId());
-        assertEquals(receivedArtifact.getDependencies().length, 0, "All dependencies should have been removed.");
+        assertEquals(receivedArtifact.getDependencies().length, 1, "Only endpoint dependency is expected.");
 
         artifactManager.removeGenericArtifact(receivedArtifact.getId());
     }
@@ -194,7 +194,7 @@ public class RESTServiceUpdateTestCase extends GREGIntegrationBaseTest {
         String artifactId = createArtifact("RestService6");
         GenericArtifact artifact = artifactManager.getGenericArtifact(artifactId);
         artifact.setAttribute("interface_wadl",
-                "https://svn.wso2.org/repos/wso2/trunk/commons/qa/qa-artifacts/greg/wadl/SearchSearvice.wadl");
+                "https://raw.githubusercontent.com/wso2/wso2-qa-artifacts/master/automation-artifacts/greg/wadl/SearchSearvice.wadl");
 
 
         artifactManager.updateGenericArtifact(artifact);

--- a/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-metadata/tests-metadata-generic/src/test/resources/testng.xml
@@ -8,6 +8,7 @@
             <package name="org.wso2.carbon.registry.metadata.test.uri.*"/>
             <package name="org.wso2.carbon.registry.metadata.test.util.*"/>
             <package name="org.wso2.carbon.registry.metadata.test.server.*"/>
+            <package name="org.wso2.carbon.registry.metadata.test.restservice.*"/>
         </packages>
 
         <classes>


### PR DESCRIPTION
Test cases added to test the new RESTServiceMediaTypeHandler.

Also added the registry.xml entry to register the new handler.


Jira Issues
[REGISTRY-3532](https://wso2.org/jira/browse/REGISTRY-3532)
[REGISTRY-3577](https://wso2.org/jira/browse/REGISTRY-3577)
[REGISTRY-3579](https://wso2.org/jira/browse/REGISTRY-3579)