### PR TITLE
Remove redundant registry put calls

### DIFF
--- a/modules/distribution/src/main/resources/greg-migration-client/src/main/java/org/wso2/carbon/greg/migration/client/ProviderMigrationClient.java
+++ b/modules/distribution/src/main/resources/greg-migration-client/src/main/java/org/wso2/carbon/greg/migration/client/ProviderMigrationClient.java
@@ -268,12 +268,13 @@ public class ProviderMigrationClient {
                         Node node = childrenList.item(j);
                         if (Constants.PROVIDER.equals(node.getNodeName())) {
                             overview.removeChild(node);
+                            String newContentString = documentToString(dom);
+                            byte[] newContentObject = RegistryUtils.encodeString(newContentString);
+                            childResource.setContent(newContentObject);
+                            registry.put(path, childResource);
                         }
                     }
-                    String newContentString = documentToString(dom);
-                    byte[] newContentObject = RegistryUtils.encodeString(newContentString);
-                    childResource.setContent(newContentObject);
-                    registry.put(path, childResource);
+
                 }
             }
         }


### PR DESCRIPTION
Earlier, a registry put will be called on assets that did not have provider element as well.
Removed that behaviour. Now only assets which contain provider element in the metadata will be put again after modified.