### PR TITLE
Fix for REGISTRY-3611

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
@@ -163,6 +163,15 @@ asset.renderer = function(ctx) {
 };
 asset.configure = function() {
     return {
+        table: {
+            overview: {
+                fields: {
+                    provider: {
+                        auto: false
+                    }
+                }
+            }
+        },
         meta: {
             lifecycle: {
                 commentRequired: false,


### PR DESCRIPTION
This PR is related to [REGISTRY-3611](https://wso2.org/jira/browse/REGISTRY-3611)

Disabled 'auto' read-only configuration from `overview_provider` field in asset create page.