### PR TITLE
REGISTRY-3580 Fix- Dynamically change subscription list based on conetnt type or metadata type artifacts

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
@@ -160,7 +160,7 @@ asset.renderer = function(ctx) {
             },
             checkSubscriptionMenuItems:function(page) {
                 page.isContentType = false;
-                if(page.rxt && page.rxt.fileExtension){
+                if(page.rxt && page.rxt.fileExtension) {
                     page.isContentType = true;
                 }
             }

--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/asset.js
@@ -157,6 +157,12 @@ asset.renderer = function(ctx) {
                     {field: "overview_name", label: "Name"},
                     {field: "overview_version", label: "Version"},
                     {field: "createdDate", label: "Date/Time"}]);
+            },
+            checkSubscriptionMenuItems:function(page) {
+                page.isContentType = false;
+                if(page.rxt && page.rxt.fileExtension){
+                    page.isContentType = true;
+                }
             }
         }
     };

--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/notifications-settings-container.hbs
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/notifications-settings-container.hbs
@@ -9,13 +9,19 @@
             <td>{{t "Lifecycle State Change"}}</td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.PublisherLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.email.id}}"  data-method='PublisherLifeCycleStateChanged' data-type="email" >
+                    <input type="checkbox" id="lifeCycleStateChangedEmail"
+                           {{#if subscriptions.PublisherLifeCycleStateChanged.email.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherLifeCycleStateChanged.email.id}}"
+                           data-method='PublisherLifeCycleStateChanged' data-type="email">
                     <span class="helper"></span>
                 </label>
             </td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.PublisherLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.work.id}}" data-method='PublisherLifeCycleStateChanged' data-type="work" >
+                    <input type="checkbox" id="lifeCycleStateChangedWork"
+                           {{#if subscriptions.PublisherLifeCycleStateChanged.work.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherLifeCycleStateChanged.work.id}}"
+                           data-method='PublisherLifeCycleStateChanged' data-type="work">
                     <span class="helper"></span>
                 </label>
             </td>
@@ -25,13 +31,19 @@
         <td>{{t "Information Update"}}</td>
         <td>
             <label class="wr-input-control switch">
-                <input type="checkbox"  id="resourceUpdatedEmail" {{#if subscriptions.PublisherResourceUpdated.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherResourceUpdated.email.id}}" data-method='PublisherResourceUpdated' data-type="email" >
+                <input type="checkbox" id="resourceUpdatedEmail"
+                       {{#if subscriptions.PublisherResourceUpdated.email.checked}}checked{{/if}}
+                       data-id="{{subscriptions.PublisherResourceUpdated.email.id}}"
+                       data-method='PublisherResourceUpdated' data-type="email">
                 <span class="helper"></span>
             </label>
         </td>
         <td>
             <label class="wr-input-control switch">
-                <input type="checkbox"  id="resourceUpdatedWork" {{#if subscriptions.PublisherResourceUpdated.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherResourceUpdated.work.id}}" data-method='PublisherResourceUpdated' data-type="work" >
+                <input type="checkbox" id="resourceUpdatedWork"
+                       {{#if subscriptions.PublisherResourceUpdated.work.checked}}checked{{/if}}
+                       data-id="{{subscriptions.PublisherResourceUpdated.work.id}}"
+                       data-method='PublisherResourceUpdated' data-type="work">
                 <span class="helper"></span>
             </label>
         </td>
@@ -41,13 +53,19 @@
             <td>{{t "Check Lifecycle Item"}}</td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="checkListItemCheckedEmail" {{#if subscriptions.PublisherCheckListItemChecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.email.id}}" data-method='PublisherCheckListItemChecked' data-type="email" >
+                    <input type="checkbox" id="checkListItemCheckedEmail"
+                           {{#if subscriptions.PublisherCheckListItemChecked.email.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherCheckListItemChecked.email.id}}"
+                           data-method='PublisherCheckListItemChecked' data-type="email">
                     <span class="helper"></span>
                 </label>
             </td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="checkListItemCheckedWork" {{#if subscriptions.PublisherCheckListItemChecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.work.id}}" data-method='PublisherCheckListItemChecked' data-type="work" >
+                    <input type="checkbox" id="checkListItemCheckedWork"
+                           {{#if subscriptions.PublisherCheckListItemChecked.work.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherCheckListItemChecked.work.id}}"
+                           data-method='PublisherCheckListItemChecked' data-type="work">
                     <span class="helper"></span>
                 </label>
             </td>
@@ -57,13 +75,19 @@
             <td>{{t "UnCheck Lifecycle Item"}}</td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="checkListItemUncheckedEmail"  {{#if subscriptions.PublisherCheckListItemUnchecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.email.id}}" data-method='PublisherCheckListItemUnchecked' data-type="email" >
+                    <input type="checkbox" id="checkListItemUncheckedEmail"
+                           {{#if subscriptions.PublisherCheckListItemUnchecked.email.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherCheckListItemUnchecked.email.id}}"
+                           data-method='PublisherCheckListItemUnchecked' data-type="email">
                     <span class="helper"></span>
                 </label>
             </td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="checkListItemUncheckedWork"  {{#if subscriptions.PublisherCheckListItemUnchecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.work.id}}" data-method='PublisherCheckListItemUnchecked' data-type="work" >
+                    <input type="checkbox" id="checkListItemUncheckedWork"
+                           {{#if subscriptions.PublisherCheckListItemUnchecked.work.checked}}checked{{/if}}
+                           data-id="{{subscriptions.PublisherCheckListItemUnchecked.work.id}}"
+                           data-method='PublisherCheckListItemUnchecked' data-type="work">
                     <span class="helper"></span>
                 </label>
             </td>

--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/notifications-settings-container.hbs
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/notifications-settings-container.hbs
@@ -4,21 +4,23 @@
         <th>{{t "Email"}}</th>
         <th>{{t "Publisher"}}</th>
     </tr>
-    <tr>
-        <td>{{t "Lifecycle State Change"}}</td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.PublisherLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.email.id}}"  data-method='PublisherLifeCycleStateChanged' data-type="email" >
-                <span class="helper"></span>
-            </label>
-        </td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.PublisherLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.work.id}}" data-method='PublisherLifeCycleStateChanged' data-type="work" >
-                <span class="helper"></span>
-            </label>
-        </td>
-    </tr>
+    {{#if assets.lifecycle}}
+        <tr>
+            <td>{{t "Lifecycle State Change"}}</td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.PublisherLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.email.id}}"  data-method='PublisherLifeCycleStateChanged' data-type="email" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.PublisherLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherLifeCycleStateChanged.work.id}}" data-method='PublisherLifeCycleStateChanged' data-type="work" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+        </tr>
+    {{/if}}
     <tr>
         <td>{{t "Information Update"}}</td>
         <td>
@@ -34,34 +36,37 @@
             </label>
         </td>
     </tr>
-    <tr>
-        <td>{{t "Check Lifecycle Item"}}</td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="checkListItemCheckedEmail" {{#if subscriptions.PublisherCheckListItemChecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.email.id}}" data-method='PublisherCheckListItemChecked' data-type="email" >
-                <span class="helper"></span>
-            </label>
-        </td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="checkListItemCheckedWork" {{#if subscriptions.PublisherCheckListItemChecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.work.id}}" data-method='PublisherCheckListItemChecked' data-type="work" >
-                <span class="helper"></span>
-            </label>
-        </td>
-    </tr>
-    <tr>
-        <td>{{t "UnCheck Lifecycle Item"}}</td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="checkListItemUncheckedEmail"  {{#if subscriptions.PublisherCheckListItemUnchecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.email.id}}" data-method='PublisherCheckListItemUnchecked' data-type="email" >
-                <span class="helper"></span>
-            </label>
-        </td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="checkListItemUncheckedWork"  {{#if subscriptions.PublisherCheckListItemUnchecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.work.id}}" data-method='PublisherCheckListItemUnchecked' data-type="work" >
-                <span class="helper"></span>
-            </label>
-        </td>
-    </tr>
+    {{#if assets.lifecycle}}
+        <tr>
+            <td>{{t "Check Lifecycle Item"}}</td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="checkListItemCheckedEmail" {{#if subscriptions.PublisherCheckListItemChecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.email.id}}" data-method='PublisherCheckListItemChecked' data-type="email" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="checkListItemCheckedWork" {{#if subscriptions.PublisherCheckListItemChecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemChecked.work.id}}" data-method='PublisherCheckListItemChecked' data-type="work" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+        </tr>
+
+        <tr>
+            <td>{{t "UnCheck Lifecycle Item"}}</td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="checkListItemUncheckedEmail"  {{#if subscriptions.PublisherCheckListItemUnchecked.email.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.email.id}}" data-method='PublisherCheckListItemUnchecked' data-type="email" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="checkListItemUncheckedWork"  {{#if subscriptions.PublisherCheckListItemUnchecked.work.checked}}checked{{/if}} data-id="{{subscriptions.PublisherCheckListItemUnchecked.work.id}}" data-method='PublisherCheckListItemUnchecked' data-type="work" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+        </tr>
+    {{/if}}
 </table>

--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/sidebar-container.hbs
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/sidebar-container.hbs
@@ -49,24 +49,26 @@
 
         {{#hasAppPermission . key="GREG_COMMUNITY_FEATURES" username=cuser.username tenantId=cuser.tenantId}}
         <!-- notifications settings -->
-        <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="headingNotificationsSettings">
-                <h2 class="sub-title panel-title">
-                    <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true" aria-controls="collapseNotificationsSettings">
-                        <span class="fw-stack">
-                            <i class="fw fw-ring fw-stack-2x"></i>
-                            <i class="fw fw-arrow fw-down-arrow fw-stack-1x"></i>
-                        </span>
-                        {{t "Notifications"}}
-                    </a>
-                </h2>
-            </div>
-            <div id="collapseNotificationsSettings" class="panel-collapse collapse in" aria-labelledby="headingNotificationsSettings">
-                <div class="panel-body">
-                    {{> notifications-settings-container . }}
+            {{#unless isContentType}}  <!-- remove notification tab for content type artifacts-->
+                <div class="panel panel-default">
+                    <div class="panel-heading" role="tab" id="headingNotificationsSettings">
+                        <h2 class="sub-title panel-title">
+                            <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true" aria-controls="collapseNotificationsSettings">
+                                <span class="fw-stack">
+                                    <i class="fw fw-ring fw-stack-2x"></i>
+                                    <i class="fw fw-arrow fw-down-arrow fw-stack-1x"></i>
+                                </span>
+                                {{t "Notifications"}}
+                            </a>
+                        </h2>
+                    </div>
+                    <div id="collapseNotificationsSettings" class="panel-collapse collapse in" aria-labelledby="headingNotificationsSettings">
+                        <div class="panel-body">
+                            {{> notifications-settings-container . }}
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            {{/unless}}
         <!-- /notifications settings -->
         {{/hasAppPermission}}
     </div>

--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/sidebar-container.hbs
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/partials/sidebar-container.hbs
@@ -53,7 +53,8 @@
                 <div class="panel panel-default">
                     <div class="panel-heading" role="tab" id="headingNotificationsSettings">
                         <h2 class="sub-title panel-title">
-                            <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true" aria-controls="collapseNotificationsSettings">
+                            <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true"
+                               aria-controls="collapseNotificationsSettings">
                                 <span class="fw-stack">
                                     <i class="fw fw-ring fw-stack-2x"></i>
                                     <i class="fw fw-arrow fw-down-arrow fw-stack-1x"></i>
@@ -62,7 +63,8 @@
                             </a>
                         </h2>
                     </div>
-                    <div id="collapseNotificationsSettings" class="panel-collapse collapse in" aria-labelledby="headingNotificationsSettings">
+                    <div id="collapseNotificationsSettings" class="panel-collapse collapse in"
+                         aria-labelledby="headingNotificationsSettings">
                         <div class="panel-body">
                             {{> notifications-settings-container . }}
                         </div>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
@@ -121,6 +121,12 @@ asset.renderer = function(ctx) {
                     single_version = true;
                 }
                 page.single_version = single_version;
+            },
+            checkSubscriptionMenuItems:function(page) {
+                page.isContentType = false;
+                if(page.rxt && page.rxt.fileExtension){
+                    page.isContentType = true;
+                }
             }
         }
     }

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
@@ -124,7 +124,7 @@ asset.renderer = function(ctx) {
             },
             checkSubscriptionMenuItems:function(page) {
                 page.isContentType = false;
-                if(page.rxt && page.rxt.fileExtension){
+                if(page.rxt && page.rxt.fileExtension) {
                     page.isContentType = true;
                 }
             }

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -98,7 +98,8 @@
                         <li>
                             {{#hasAppPermission . key="GREG_COMMUNITY_FEATURES" username=cuser.username tenantId=cuser.tenantId}}
                                 {{#unless isContentType}}  <!-- remove options tab for content type artifacts-->
-                                    <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)" class="cu-btn wr-side-panel-toggle-btn">
+                                    <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)"
+                                       class="cu-btn wr-side-panel-toggle-btn">
                                     <span class="fw-stack-md options">
                                         <i class="fw fw-left-arrow fw-stack-1-5x"></i>
                                     </span>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -97,12 +97,14 @@
                     {{#if isSidebarEnabled}}
                         <li>
                             {{#hasAppPermission . key="GREG_COMMUNITY_FEATURES" username=cuser.username tenantId=cuser.tenantId}}
-                                <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)" class="cu-btn wr-side-panel-toggle-btn">
-                                <span class="fw-stack-md options">
-                                    <i class="fw fw-left-arrow fw-stack-1-5x"></i>
-                                </span>
-                                    Options
-                                </a>
+                                {{#unless isContentType}}  <!-- remove options tab for content type artifacts-->
+                                    <a href="javascript:void(0)" onclick="toggleSidePanel('options',this)" class="cu-btn wr-side-panel-toggle-btn">
+                                    <span class="fw-stack-md options">
+                                        <i class="fw fw-left-arrow fw-stack-1-5x"></i>
+                                    </span>
+                                        Options
+                                    </a>
+                                {{/unless}}
                             {{/hasAppPermission}}
                         </li>
                     {{/if}}

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/notifications-settings-container.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/notifications-settings-container.hbs
@@ -4,21 +4,23 @@
         <th>{{t "Email"}}</th>
         <th>{{t "Store"}}</th>
     </tr>
-    <tr>
-        <td>{{t "Lifecycle State Change"}}</td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.StoreLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.email.id}}"  data-method='StoreLifeCycleStateChanged' data-type="email" >
-                <span class="helper"></span>
-            </label>
-        </td>
-        <td>
-            <label class="wr-input-control switch">
-                <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.StoreLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.work.id}}" data-method='StoreLifeCycleStateChanged' data-type="work" >
-                <span class="helper"></span>
-            </label>
-        </td>
-    </tr>
+    {{#if assets.lifecycle}}
+        <tr>
+            <td>{{t "Lifecycle State Change"}}</td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.StoreLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.email.id}}"  data-method='StoreLifeCycleStateChanged' data-type="email" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+            <td>
+                <label class="wr-input-control switch">
+                    <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.StoreLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.work.id}}" data-method='StoreLifeCycleStateChanged' data-type="work" >
+                    <span class="helper"></span>
+                </label>
+            </td>
+        </tr>
+    {{/if}}
     <tr>
         <td>{{t "Information Update"}}</td>
         <td>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/notifications-settings-container.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/notifications-settings-container.hbs
@@ -9,13 +9,19 @@
             <td>{{t "Lifecycle State Change"}}</td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="lifeCycleStateChangedEmail" {{#if subscriptions.StoreLifeCycleStateChanged.email.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.email.id}}"  data-method='StoreLifeCycleStateChanged' data-type="email" >
+                    <input type="checkbox" id="lifeCycleStateChangedEmail"
+                           {{#if subscriptions.StoreLifeCycleStateChanged.email.checked}}checked{{/if}}
+                           data-id="{{subscriptions.StoreLifeCycleStateChanged.email.id}}"
+                           data-method='StoreLifeCycleStateChanged' data-type="email">
                     <span class="helper"></span>
                 </label>
             </td>
             <td>
                 <label class="wr-input-control switch">
-                    <input type="checkbox" id="lifeCycleStateChangedWork" {{#if subscriptions.StoreLifeCycleStateChanged.work.checked}}checked{{/if}} data-id="{{subscriptions.StoreLifeCycleStateChanged.work.id}}" data-method='StoreLifeCycleStateChanged' data-type="work" >
+                    <input type="checkbox" id="lifeCycleStateChangedWork"
+                           {{#if subscriptions.StoreLifeCycleStateChanged.work.checked}}checked{{/if}}
+                           data-id="{{subscriptions.StoreLifeCycleStateChanged.work.id}}"
+                           data-method='StoreLifeCycleStateChanged' data-type="work">
                     <span class="helper"></span>
                 </label>
             </td>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/sidebar-container.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/sidebar-container.hbs
@@ -8,24 +8,26 @@
 
         {{#hasAppPermission . key="GREG_COMMUNITY_FEATURES" username=cuser.username tenantId=cuser.tenantId}}
         <!-- notifications settings -->
-        <div class="panel panel-default">
-            <div class="panel-heading" role="tab" id="headingNotificationsSettings">
-                <h2 class="sub-title panel-title">
-                    <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true" aria-controls="collapseNotificationsSettings">
-                        <span class="fw-stack">
-                            <i class="fw fw-ring fw-stack-2x"></i>
-                            <i class="fw fw-arrow fw-up-arrow fw-stack-1x"></i>
-                        </span>
-                        {{t "Notifications Settings"}}
-                    </a>
-                </h2>
-            </div>
-            <div id="collapseNotificationsSettings" class="panel-collapse collapse in" aria-labelledby="headingNotificationsSettings">
-                <div class="panel-body">
-                    {{> notifications-settings-container . }}
+            {{#unless isContentType}}  <!-- remove notification tab for content type artifacts-->
+                <div class="panel panel-default">
+                    <div class="panel-heading" role="tab" id="headingNotificationsSettings">
+                        <h2 class="sub-title panel-title">
+                            <a data-toggle="collapse" href="#collapseNotificationsSettings" aria-expanded="true" aria-controls="collapseNotificationsSettings">
+                                <span class="fw-stack">
+                                    <i class="fw fw-ring fw-stack-2x"></i>
+                                    <i class="fw fw-arrow fw-up-arrow fw-stack-1x"></i>
+                                </span>
+                                {{t "Notifications Settings"}}
+                            </a>
+                        </h2>
+                    </div>
+                    <div id="collapseNotificationsSettings" class="panel-collapse collapse in" aria-labelledby="headingNotificationsSettings">
+                        <div class="panel-body">
+                            {{> notifications-settings-container . }}
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            {{/unless}}
         <!-- /notifications settings -->
         {{/hasAppPermission}}
     </div>


### PR DESCRIPTION
Publisher side fix:
Remove subscription tab for content type artifacts. 
Add life cycle related subscriptions only if life cycle is attached to the particular asset 

Store side fix:
Remove options tab completely for content type artifacts. 
Add life cycle related subscriptions only if life cycle is attached to the particular asset 