### PR TITLE
REGISTRY-3634 : Override sort attributes.

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
@@ -130,7 +130,13 @@ asset.configure = function() {
     return {
         meta: {
             'isDependencyShown': true,
-            'isDiffViewShown': true
+            'isDiffViewShown': true,
+            sorting: {
+                attributes: [
+                    {name: "overview_name", label: "Name"},
+                    {name: "createdDate", label: "Date/Time"}
+                ]
+            }
         }
     }
 };


### PR DESCRIPTION
PR related to [REGISTRY-3634](https://wso2.org/jira/browse/REGISTRY-3634)

Overriding sort attributes names in Greg side as overview_createdtime is not included in governance artifacts.