### PR TITLE
Fix for REGISTRY-3647

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/asset.js
@@ -131,6 +131,7 @@ asset.configure = function() {
         meta: {
             'isDependencyShown': true,
             'isDiffViewShown': true,
+            timestamp:'createdDate',
             sorting: {
                 attributes: [
                     {name: "overview_name", label: "Name"},


### PR DESCRIPTION
Changed the timestamp attribute to createdDate

Depends on the following PR: https://github.com/wso2/carbon-store/pull/654

Addresses the following issue: [REGISTRY-3647](https://wso2.org/jira/browse/REGISTRY-3647)