### PR TITLE
Fix for REGISTRY-3813: Remove unwanted bootstrap column classes

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -132,7 +132,7 @@
                 </div>
             </div>
 
-            <div class="col-sm-3 col-md-5 col-lg-3 top-menu-right-custom right">
+            <div class="top-menu-right-custom right">
                 <div>
                     {{#hasAppPermission . key="APP_MYITEMS" username=cuser.username tenantId=cuser.tenantId}}
                         <a href="{{url "/pages/my-items"}}" class="bookmark-link"


### PR DESCRIPTION
In this PR:

* Remove unwanted CSS classes which overlap the search button.

Address the following issue : [REGISTRY-3813](https://wso2.org/jira/browse/REGISTRY-3813)