### PR TITLE
Populating categorization for BuyMore assets

### DIFF
--- a/modules/samples/getting_started/src/org/wso2/carbon/registry/samples/populator/CategorizeArtifacts.java
+++ b/modules/samples/getting_started/src/org/wso2/carbon/registry/samples/populator/CategorizeArtifacts.java
@@ -116,9 +116,9 @@ public class CategorizeArtifacts {
                 for (GenericArtifact artifact : restServices) {
                     if (restServicesList.contains(artifact.getQName().getLocalPart())) {
                         String lifeCycleName = artifact.getLifecycleName();
-                        if(!BUYMORE_LIFE_CYCLE.equals(lifeCycleName)) {
-                            String environment = environments[i % 5];
-                            String level = levels[i % 4];
+                        String environment = environments[i % 5];
+                        String level = levels[i % 4];
+                        if (!BUYMORE_LIFE_CYCLE.equals(lifeCycleName)) {
                             artifact.setAttribute("categorization_environment", environment);
                             artifact.setAttribute("categorization_level", level);
                             artifactManager1.updateGenericArtifact(artifact);
@@ -130,8 +130,9 @@ public class CategorizeArtifacts {
                             }
                             i++;
                         } else {
-                            String category = "Sales";
-                            artifact.setAttribute("overview_category", category);
+                            environment = "Sales";
+                            artifact.setAttribute("categorization_environment", environment);
+                            artifact.setAttribute("categorization_level", level);
                             artifactManager1.updateGenericArtifact(artifact);
                             String path = artifact.getPath();
                             gov.applyTag(path, "BuyMore");


### PR DESCRIPTION
This PR is related with [REGISTRY-3811](https://wso2.org/jira/browse/REGISTRY-3811)

Above issue is occurring because BuyMore assets do not have applied categories. To avoid confusion this PR modifies the sample populator to apply categories to BuyMore assets.