### PR TITLE
Fix for REGISTRY-3819 : Show asset related tag in asset details page

### DIFF
--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/navigation.hbs
@@ -90,9 +90,11 @@
         </div>
 
         {{#if tags}}
-            <div class="tags-wrapper" id="tags-wrapper">
-                {{> tag-cloud .}}
-            </div>
+            {{#if showTagCloud}}
+                <div class="tags-wrapper" id="tags-wrapper">
+                    {{> tag-cloud . }}
+                </div>
+            {{/if}}
         {{/if}}
 
     </div>

--- a/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/tag-cloud.hbs
+++ b/modules/es-extensions/store/extensions/app/greg-store-defaults/themes/store/partials/tag-cloud.hbs
@@ -1,26 +1,40 @@
 <div class="tag-title"> Tags</div>
 <div id="tag-container" class="tag-content">
-    {{#each tags}}
-        {{#if this.selected}}
+    {{#if appliedTags }}
+        {{#each appliedTags}}
             {{#if ../../assetCategoryDetails.hasCategories}}
-                <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span
-                        class="es-remove-tag text-muted">{{this.value}}</span><i class="es-remove-tag fw fw-cancel"></i></a>
-            {{else}}
-                <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span
-                        class="es-remove-tag text-muted">{{this.value}}</span><i class="es-remove-tag  fw fw-cancel"></i></a>
-            {{/if}}
-        {{else}}
-            {{#if ../../assetCategoryDetails.hasCategories}}
-                <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'>
-                <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                <a href='{{tenantedUrl ""}}/assets/{{ ../../assets/type}}/list?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this}}"'>
+                    <span class="es-applied-tag text-muted">{{this}}</span>
                 </a>
             {{else}}
-                <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'>
-                    <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                <a href='{{tenantedUrl ""}}/assets/{{ ../../assets/type}}/list?q="tags":"{{this}}"'>
+                    <span class="es-applied-tag text-muted">{{this}}</span>
                 </a>
             {{/if}}
-        {{/if}}
-    {{/each}}
+        {{/each}}
+    {{else}}
+        {{#each tags}}
+            {{#if this.selected}}
+                {{#if ../../assetCategoryDetails.hasCategories}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span
+                            class="es-remove-tag text-muted">{{this.value}}</span><i class="es-remove-tag fw fw-cancel"></i></a>
+                {{else}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span
+                            class="es-remove-tag text-muted">{{this.value}}</span><i class="es-remove-tag  fw fw-cancel"></i></a>
+                {{/if}}
+            {{else}}
+                {{#if ../../assetCategoryDetails.hasCategories}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'>
+                        <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                    </a>
+                {{else}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'>
+                        <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                    </a>
+                {{/if}}
+            {{/if}}
+        {{/each}}
+    {{/if}}
 </div>
 <div id="tags-collapse" class="tags-collapse">
     <p class="small">


### PR DESCRIPTION
In this PR:

* Show tag cloud with relevant tags in asset detail page

Address the following issue: [REGISTRY-3819](https://wso2.org/jira/browse/REGISTRY-3819)

This PR **depends** on PR [#774](https://github.com/wso2/carbon-store/pull/774)