### PR TITLE
Revert select2 field height changes to default

### DIFF
--- a/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/css/common.css
+++ b/modules/es-extensions/publisher/extensions/app/greg-publisher-defaults/themes/default/css/common.css
@@ -461,7 +461,7 @@ select.select2 {
 
 .select2-container--default .select2-selection--multiple, .select2-container--default .select2-selection--single {
     border-radius: 0;
-    min-height: 85px;
+    min-height: 34px;
     border: 1px solid #999;
 }
 


### PR DESCRIPTION
Change the select2 field height to default value. It was change with association page changes, but this css property doesn't used in association dropdown. It uses below value,

/* Association page asset drop down */
span.select2-selection.select2-selection--single.select-resource {
height: 85px !important;
}

This value affects select2 dropdown in publisher create and update pages.